### PR TITLE
feat(btx): wire caller IP into BTX audit row + fix stale plan docs

### DIFF
--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/CommandService.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/CommandService.java
@@ -15,6 +15,7 @@
  */
 package io.github.bmarwell.keyserver.application.api;
 
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
 
 public interface CommandService {
@@ -24,5 +25,9 @@ public interface CommandService {
     /// The command runs asynchronously inside a business transaction (BTX).
     /// Any failure is recorded in the BTX audit row and logged; it does NOT
     /// propagate back to the caller.
-    <T extends KeyServerCommand> void handleCommand(T keyServerCommand);
+    ///
+    /// @param keyServerCommand the command to execute
+    /// @param callerContext    caller metadata (pre-anonymized IP, etc.); use
+    ///                         {@link CommandCallerContext#empty()} if unavailable
+    <T extends KeyServerCommand> void handleCommand(T keyServerCommand, CommandCallerContext callerContext);
 }

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/AddKeyToVerificationQueueCommand.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/AddKeyToVerificationQueueCommand.java
@@ -15,6 +15,8 @@
  */
 package io.github.bmarwell.keyserver.application.api.commands;
 
+import java.util.Optional;
+
 /// Command to submit a PGP public key for email-based ownership verification.
 ///
 /// The primary adapter (`AddEndpoint`) reads the ASCII-armored key text from the
@@ -26,4 +28,16 @@ package io.github.bmarwell.keyserver.application.api.commands;
 /// The `anonymizedClientIp` field must already be anonymized (IPv4 last octet
 /// zeroed, IPv6 last 80 bits zeroed) before this record is constructed.  No
 /// downstream component should receive or store a raw IP.
-public record AddKeyToVerificationQueueCommand(String keyText, String anonymizedClientIp) implements KeyServerCommand {}
+///
+/// The anonymized IP is forwarded to the BTX audit row automatically via
+/// {@link #callerIp()} — see implementation-plan §8.7.
+public record AddKeyToVerificationQueueCommand(String keyText, String anonymizedClientIp) implements KeyServerCommand {
+
+    @Override
+    public Optional<String> callerIp() {
+        if (anonymizedClientIp == null || anonymizedClientIp.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(anonymizedClientIp);
+    }
+}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/AddKeyToVerificationQueueCommand.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/AddKeyToVerificationQueueCommand.java
@@ -15,29 +15,15 @@
  */
 package io.github.bmarwell.keyserver.application.api.commands;
 
-import java.util.Optional;
-
 /// Command to submit a PGP public key for email-based ownership verification.
 ///
 /// The primary adapter (`AddEndpoint`) reads the ASCII-armored key text from the
-/// HTTP request body **synchronously**, anonymizes the caller's IP, and then
-/// builds this command before handing it to `CommandService`.  Passing a
-/// `String` (rather than an `InputStream`) avoids a closed-stream race when the
-/// virtual-thread executor picks up the command after the HTTP thread returns.
+/// HTTP request body **synchronously** and builds this command before handing it
+/// to `CommandService`.  Passing a `String` (rather than an `InputStream`) avoids
+/// a closed-stream race when the virtual-thread executor picks up the command after
+/// the HTTP thread returns.
 ///
-/// The `anonymizedClientIp` field must already be anonymized (IPv4 last octet
-/// zeroed, IPv6 last 80 bits zeroed) before this record is constructed.  No
-/// downstream component should receive or store a raw IP.
-///
-/// The anonymized IP is forwarded to the BTX audit row automatically via
-/// {@link #callerIp()} — see implementation-plan §8.7.
-public record AddKeyToVerificationQueueCommand(String keyText, String anonymizedClientIp) implements KeyServerCommand {
-
-    @Override
-    public Optional<String> callerIp() {
-        if (anonymizedClientIp == null || anonymizedClientIp.isBlank()) {
-            return Optional.empty();
-        }
-        return Optional.of(anonymizedClientIp);
-    }
-}
+/// Caller metadata (anonymized IP) is **not** part of this record.  It travels in
+/// the accompanying {@link CommandCallerContext} so that command records stay focused
+/// on business payload.  See implementation-plan §8.7.
+public record AddKeyToVerificationQueueCommand(String keyText) implements KeyServerCommand {}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/AddKeyToVerificationQueueCommand.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/AddKeyToVerificationQueueCommand.java
@@ -15,6 +15,8 @@
  */
 package io.github.bmarwell.keyserver.application.api.commands;
 
+import org.jspecify.annotations.Nullable;
+
 /// Command to submit a PGP public key for email-based ownership verification.
 ///
 /// The primary adapter (`AddEndpoint`) reads the ASCII-armored key text from the
@@ -23,7 +25,10 @@ package io.github.bmarwell.keyserver.application.api.commands;
 /// a closed-stream race when the virtual-thread executor picks up the command after
 /// the HTTP thread returns.
 ///
+/// `keyText` may be `null` when the form parameter is absent; the command handler
+/// is responsible for validation and rejection in that case.
+///
 /// Caller metadata (anonymized IP) is **not** part of this record.  It travels in
 /// the accompanying {@link CommandCallerContext} so that command records stay focused
 /// on business payload.  See implementation-plan §8.7.
-public record AddKeyToVerificationQueueCommand(String keyText) implements KeyServerCommand {}
+public record AddKeyToVerificationQueueCommand(@Nullable String keyText) implements KeyServerCommand {}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/CommandCallerContext.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/CommandCallerContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.keyserver.application.api.commands;
+
+/// Caller metadata that travels alongside a command through the dispatch chain.
+///
+/// Unlike the command record (which carries business payload), `CommandCallerContext`
+/// carries execution metadata — currently the pre-anonymized caller IP.
+/// Both the command service and each command handler receive it explicitly so
+/// the information is visible in method signatures rather than hidden behind CDI injection.
+///
+/// ## IP anonymization contract
+///
+/// The `anonymizedCallerIp` value **must** already be anonymized (IPv4 last octet
+/// zeroed, IPv6 last 80 bits zeroed) by the primary adapter before this context
+/// is constructed.  No component downstream should receive or store a raw IP.
+///
+/// Use {@link #empty()} when no caller IP is available (e.g., internally triggered commands).
+public record CommandCallerContext(String anonymizedCallerIp) {
+
+    /// Returns a context with no caller IP (e.g., for internally triggered commands).
+    public static CommandCallerContext empty() {
+        return new CommandCallerContext(null);
+    }
+
+    /// Returns a context carrying a pre-anonymized caller IP.
+    public static CommandCallerContext of(String anonymizedCallerIp) {
+        return new CommandCallerContext(anonymizedCallerIp);
+    }
+}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/CommandCallerContext.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/CommandCallerContext.java
@@ -15,6 +15,8 @@
  */
 package io.github.bmarwell.keyserver.application.api.commands;
 
+import org.jspecify.annotations.Nullable;
+
 /// Caller metadata that travels alongside a command through the dispatch chain.
 ///
 /// Unlike the command record (which carries business payload), `CommandCallerContext`
@@ -29,7 +31,7 @@ package io.github.bmarwell.keyserver.application.api.commands;
 /// is constructed.  No component downstream should receive or store a raw IP.
 ///
 /// Use {@link #empty()} when no caller IP is available (e.g., internally triggered commands).
-public record CommandCallerContext(String anonymizedCallerIp) {
+public record CommandCallerContext(@Nullable String anonymizedCallerIp) {
 
     /// Returns a context with no caller IP (e.g., for internally triggered commands).
     public static CommandCallerContext empty() {

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/KeyServerCommand.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/KeyServerCommand.java
@@ -15,4 +15,27 @@
  */
 package io.github.bmarwell.keyserver.application.api.commands;
 
-public interface KeyServerCommand {}
+import java.util.Optional;
+
+/// Marker interface for all commands dispatched through the {@link
+/// io.github.bmarwell.keyserver.application.api.CommandService}.
+///
+/// Commands may optionally carry a pre-anonymized caller IP by overriding
+/// {@link #callerIp()}.  The command service reads this value and forwards it
+/// to the business-transaction audit row without any explicit parameter threading
+/// through the handler stack.
+public interface KeyServerCommand {
+
+    /// Returns the pre-anonymized caller IP for audit purposes.
+    ///
+    /// The default implementation returns {@link Optional#empty()}, which tells
+    /// the command service to record {@code null} in the BTX row.
+    /// Commands that capture a caller IP (e.g., HTTP-originated commands) should
+    /// override this method and return the value that was already anonymized by
+    /// {@code IpAnonymizer} before the command was constructed.
+    ///
+    /// @return the anonymized caller IP, or empty if unavailable
+    default Optional<String> callerIp() {
+        return Optional.empty();
+    }
+}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/KeyServerCommand.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/KeyServerCommand.java
@@ -15,27 +15,9 @@
  */
 package io.github.bmarwell.keyserver.application.api.commands;
 
-import java.util.Optional;
-
-/// Marker interface for all commands dispatched through the {@link
-/// io.github.bmarwell.keyserver.application.api.CommandService}.
+/// Marker interface for all commands dispatched through the
+/// {@link io.github.bmarwell.keyserver.application.api.CommandService}.
 ///
-/// Commands may optionally carry a pre-anonymized caller IP by overriding
-/// {@link #callerIp()}.  The command service reads this value and forwards it
-/// to the business-transaction audit row without any explicit parameter threading
-/// through the handler stack.
-public interface KeyServerCommand {
-
-    /// Returns the pre-anonymized caller IP for audit purposes.
-    ///
-    /// The default implementation returns {@link Optional#empty()}, which tells
-    /// the command service to record {@code null} in the BTX row.
-    /// Commands that capture a caller IP (e.g., HTTP-originated commands) should
-    /// override this method and return the value that was already anonymized by
-    /// {@code IpAnonymizer} before the command was constructed.
-    ///
-    /// @return the anonymized caller IP, or empty if unavailable
-    default Optional<String> callerIp() {
-        return Optional.empty();
-    }
-}
+/// Commands carry business payload only.  Execution metadata (caller IP, etc.)
+/// travels in the accompanying {@link CommandCallerContext}.
+public interface KeyServerCommand {}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/package-info.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Command types and caller-context value objects for the primary application port.
+///
+/// All types in this package are non-null by default (jspecify `@NullMarked`).
+/// Fields and parameters that may be `null` are explicitly annotated with
+/// {@link org.jspecify.annotations.Nullable}.
+@NullMarked
+package io.github.bmarwell.keyserver.application.api.commands;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
@@ -18,18 +18,14 @@ package io.github.bmarwell.keyserver.application.core;
 import io.github.bmarwell.keyserver.application.api.CommandService;
 import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
-import io.github.bmarwell.keyserver.application.core.cmdhandler.CommandHandler;
 import io.github.bmarwell.keyserver.application.core.concurrent.BusinessTransactionContext;
 import io.github.bmarwell.keyserver.application.port.repository.BusinessTransactionRepository;
 import io.hypersistence.tsid.TSID;
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
-import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -53,7 +49,10 @@ import java.util.logging.Logger;
 /// 3. The BTX ID is stored in the `@RequestScoped` `BusinessTransactionContext`
 ///    so that any downstream component (audit writer, DAO) can reference it
 ///    without explicit parameter passing.
-/// 4. The command handler runs inside a `@Transactional` boundary.
+/// 4. The command handler runs inside a `@Transactional` boundary provided by
+///    the injected {@link TransactionalCommandDispatcher}.  Using a separate
+///    bean ensures CDI interceptors fire through the proxy rather than being
+///    bypassed by a same-bean self-invocation.
 /// 5. On success the BTX row is updated to `COMPLETED` (also `REQUIRES_NEW`).
 /// 6. On any exception the BTX row is updated to `FAILED` (`REQUIRES_NEW`) and
 ///    the exception is logged.  It does NOT propagate back — the caller fired and forgot.
@@ -65,8 +64,7 @@ public class KeyServerCommandService implements CommandService, Serializable {
     private static final Logger LOG = Logger.getLogger(KeyServerCommandService.class.getName());
 
     @Inject
-    @Any
-    Instance<CommandHandler<? extends KeyServerCommand>> commandHandlers;
+    TransactionalCommandDispatcher dispatcher;
 
     @Inject
     BusinessTransactionRepository btxRepository;
@@ -87,7 +85,7 @@ public class KeyServerCommandService implements CommandService, Serializable {
         btxContext.initialize(btxId);
 
         try {
-            dispatch(keyServerCommand, callerContext);
+            dispatcher.dispatch(keyServerCommand, callerContext);
             btxRepository.recordCompleted(btxId);
         } catch (Exception ex) {
             btxRepository.recordFailed(btxId, ex.getClass().getSimpleName(), ex.getMessage());
@@ -97,22 +95,10 @@ public class KeyServerCommandService implements CommandService, Serializable {
         }
     }
 
-    @Transactional
-    @SuppressWarnings("unchecked")
-    private <T extends KeyServerCommand> void dispatch(T command, CommandCallerContext callerContext) {
-        CommandHandler<T> handler = (CommandHandler<T>) commandHandlers.stream()
-                .filter(ch -> ch.canHandle(command))
-                .findFirst()
-                .orElseThrow(() -> new UnsupportedOperationException(
-                        "No CommandHandler for: " + command.getClass().getName()));
-
-        handler.execute(command, callerContext);
-    }
-
     // CDI-friendly setters for testing
 
-    public void setCommandHandlers(Instance<CommandHandler<? extends KeyServerCommand>> commandHandlers) {
-        this.commandHandlers = commandHandlers;
+    public void setDispatcher(TransactionalCommandDispatcher dispatcher) {
+        this.dispatcher = dispatcher;
     }
 
     public void setBtxRepository(BusinessTransactionRepository btxRepository) {

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
@@ -82,7 +82,8 @@ public class KeyServerCommandService implements CommandService, Serializable {
         long btxId = tsidFactory.generate().toLong();
         String commandType = keyServerCommand.getClass().getSimpleName();
 
-        btxRepository.recordStarted(btxId, commandType, null);
+        btxRepository.recordStarted(
+                btxId, commandType, keyServerCommand.callerIp().orElse(null));
         btxContext.initialize(btxId);
 
         try {

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
@@ -16,6 +16,7 @@
 package io.github.bmarwell.keyserver.application.core;
 
 import io.github.bmarwell.keyserver.application.api.CommandService;
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
 import io.github.bmarwell.keyserver.application.core.cmdhandler.CommandHandler;
 import io.github.bmarwell.keyserver.application.core.concurrent.BusinessTransactionContext;
@@ -78,16 +79,15 @@ public class KeyServerCommandService implements CommandService, Serializable {
 
     @Asynchronous(executor = "java:app/concurrent/KeyServerCommandExecutor")
     @Override
-    public <T extends KeyServerCommand> void handleCommand(T keyServerCommand) {
+    public <T extends KeyServerCommand> void handleCommand(T keyServerCommand, CommandCallerContext callerContext) {
         long btxId = tsidFactory.generate().toLong();
         String commandType = keyServerCommand.getClass().getSimpleName();
 
-        btxRepository.recordStarted(
-                btxId, commandType, keyServerCommand.callerIp().orElse(null));
+        btxRepository.recordStarted(btxId, commandType, callerContext.anonymizedCallerIp());
         btxContext.initialize(btxId);
 
         try {
-            dispatch(keyServerCommand);
+            dispatch(keyServerCommand, callerContext);
             btxRepository.recordCompleted(btxId);
         } catch (Exception ex) {
             btxRepository.recordFailed(btxId, ex.getClass().getSimpleName(), ex.getMessage());
@@ -99,14 +99,14 @@ public class KeyServerCommandService implements CommandService, Serializable {
 
     @Transactional
     @SuppressWarnings("unchecked")
-    private <T extends KeyServerCommand> void dispatch(T command) {
+    private <T extends KeyServerCommand> void dispatch(T command, CommandCallerContext callerContext) {
         CommandHandler<T> handler = (CommandHandler<T>) commandHandlers.stream()
                 .filter(ch -> ch.canHandle(command))
                 .findFirst()
                 .orElseThrow(() -> new UnsupportedOperationException(
                         "No CommandHandler for: " + command.getClass().getName()));
 
-        handler.execute(command);
+        handler.execute(command, callerContext);
     }
 
     // CDI-friendly setters for testing

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/TransactionalCommandDispatcher.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/TransactionalCommandDispatcher.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.keyserver.application.core;
+
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
+import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
+import io.github.bmarwell.keyserver.application.core.cmdhandler.CommandHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+/// Locates the right {@link CommandHandler} for a command and executes it inside a
+/// single JTA transaction.
+///
+/// ## Why a separate bean?
+///
+/// CDI interceptors (e.g., `@Transactional`) are applied via proxy and only fire on
+/// method calls that pass **through the proxy** — i.e., calls from one CDI bean to
+/// another.  A private or self-invoked method in the same class bypasses the proxy
+/// and therefore receives no interception.
+///
+/// By extracting the dispatch step into its own `@ApplicationScoped` bean, the
+/// `@Transactional` annotation reliably opens a JTA transaction around the handler
+/// call so that all DAO writes made by the handler participate in a single unit of
+/// work.  BTX lifecycle writes (`recordStarted`, `recordCompleted`, `recordFailed`)
+/// use `REQUIRES_NEW` and therefore always commit independently.
+@ApplicationScoped
+class TransactionalCommandDispatcher {
+
+    @Inject
+    @Any
+    Instance<CommandHandler<? extends KeyServerCommand>> commandHandlers;
+
+    /// Finds the handler for {@code command} and executes it within a `REQUIRED`
+    /// JTA transaction.  Throws {@link UnsupportedOperationException} (which the
+    /// caller catches) if no handler is registered.
+    @Transactional
+    @SuppressWarnings("unchecked")
+    public <T extends KeyServerCommand> void dispatch(T command, CommandCallerContext callerContext) {
+        CommandHandler<T> handler = (CommandHandler<T>) commandHandlers.stream()
+                .filter(ch -> ch.canHandle(command))
+                .findFirst()
+                .orElseThrow(() -> new UnsupportedOperationException(
+                        "No CommandHandler for: " + command.getClass().getName()));
+
+        handler.execute(command, callerContext);
+    }
+
+    // CDI-friendly setter for unit testing
+    public void setCommandHandlers(Instance<CommandHandler<? extends KeyServerCommand>> commandHandlers) {
+        this.commandHandlers = commandHandlers;
+    }
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AbstractKeyServerCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AbstractKeyServerCommandHandler.java
@@ -15,14 +15,15 @@
  */
 package io.github.bmarwell.keyserver.application.core.cmdhandler;
 
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommandResponse;
 
 public abstract class AbstractKeyServerCommandHandler<T extends KeyServerCommand> implements CommandHandler<T> {
 
-    public KeyServerCommandResponse execute(KeyServerCommand command) {
-        return doExecute((T) command);
+    public KeyServerCommandResponse execute(KeyServerCommand command, CommandCallerContext callerContext) {
+        return doExecute((T) command, callerContext);
     }
 
-    abstract KeyServerCommandResponse doExecute(T command);
+    abstract KeyServerCommandResponse doExecute(T command, CommandCallerContext callerContext);
 }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
@@ -16,6 +16,7 @@
 package io.github.bmarwell.keyserver.application.core.cmdhandler;
 
 import io.github.bmarwell.keyserver.application.api.commands.AddKeyToVerificationQueueCommand;
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommandResponse;
 import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
@@ -64,12 +65,12 @@ import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
 /// Tokens expire after {@value #TOKEN_TTL_HOURS} hours by default.  A future
 /// iteration will make this configurable via MicroProfile Config.
 ///
-/// ## anonymizedClientIp
+/// ## Caller context
 ///
-/// The command carries the pre-anonymized client IP for audit purposes.
-/// It is not persisted here — it will be written to the BTX audit row once
-/// `BusinessTransactionRepository.recordStarted()` is extended to accept
-/// optional metadata (see implementation-plan §7.7).
+/// The `CommandCallerContext` carries the pre-anonymized caller IP for audit
+/// purposes.  This handler does not need the IP directly — it was already
+/// forwarded to the BTX audit row by `KeyServerCommandService`.  The parameter
+/// is present to satisfy the handler contract (see implementation-plan §8.7).
 @RequestScoped
 public class AddKeyToVerificationQueueCommandHandler
         extends AbstractKeyServerCommandHandler<AddKeyToVerificationQueueCommand> {
@@ -88,7 +89,7 @@ public class AddKeyToVerificationQueueCommandHandler
     }
 
     @Override
-    KeyServerCommandResponse doExecute(AddKeyToVerificationQueueCommand command) {
+    KeyServerCommandResponse doExecute(AddKeyToVerificationQueueCommand command, CommandCallerContext callerContext) {
         if (command.keyText() == null || command.keyText().isBlank()) {
             throw new KeyParsingException("keytext must not be null or blank");
         }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/CommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/CommandHandler.java
@@ -15,6 +15,7 @@
  */
 package io.github.bmarwell.keyserver.application.core.cmdhandler;
 
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommandResponse;
 
@@ -22,5 +23,5 @@ public interface CommandHandler<T extends KeyServerCommand> {
 
     <C extends KeyServerCommand> boolean canHandle(C command);
 
-    KeyServerCommandResponse execute(KeyServerCommand command);
+    KeyServerCommandResponse execute(KeyServerCommand command, CommandCallerContext callerContext);
 }

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -17,6 +17,7 @@ package io.github.bmarwell.keyserver.application.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
 import io.github.bmarwell.keyserver.application.core.concurrent.BusinessTransactionContext;
 import io.github.bmarwell.keyserver.application.port.repository.BusinessTransactionRepository;
@@ -40,7 +41,7 @@ class KeyServerCommandServiceTest {
                 TSID.Factory.builder().withNodeBits(10).withNode(0).build());
 
         // when: @Asynchronous is not intercepted in unit tests — runs synchronously
-        service.handleCommand(noopCommand);
+        service.handleCommand(noopCommand, CommandCallerContext.empty());
 
         // then: BTX was started and then recorded as failed with the exception type
         assertThat(trackingRepo.startedCount).isEqualTo(1);

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -19,26 +19,36 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
+import io.github.bmarwell.keyserver.application.core.cmdhandler.CommandHandler;
 import io.github.bmarwell.keyserver.application.core.concurrent.BusinessTransactionContext;
 import io.github.bmarwell.keyserver.application.port.repository.BusinessTransactionRepository;
 import io.github.bmarwell.keyserver.test.utils.cdi.SimpleInstance;
 import io.hypersistence.tsid.TSID;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 class KeyServerCommandServiceTest {
+
+    private static KeyServerCommandService buildService(
+            TrackingBusinessTransactionRepository trackingRepo,
+            SimpleInstance<CommandHandler<? extends KeyServerCommand>> handlers) {
+        var dispatcher = new TransactionalCommandDispatcher();
+        dispatcher.setCommandHandlers(handlers);
+        KeyServerCommandService service = new KeyServerCommandService();
+        service.setDispatcher(dispatcher);
+        service.setBtxRepository(trackingRepo);
+        service.setBtxContext(new BusinessTransactionContext());
+        service.setTsidFactory(
+                TSID.Factory.builder().withNodeBits(10).withNode(0).build());
+        return service;
+    }
 
     @Test
     void records_failed_on_unknown_command_type() {
         // given:
         var noopCommand = new KeyServerCommand() {};
         var trackingRepo = new TrackingBusinessTransactionRepository();
-
-        KeyServerCommandService service = new KeyServerCommandService();
-        service.setCommandHandlers(SimpleInstance.empty());
-        service.setBtxRepository(trackingRepo);
-        service.setBtxContext(new BusinessTransactionContext());
-        service.setTsidFactory(
-                TSID.Factory.builder().withNodeBits(10).withNode(0).build());
+        KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.empty());
 
         // when: @Asynchronous is not intercepted in unit tests — runs synchronously
         service.handleCommand(noopCommand, CommandCallerContext.empty());
@@ -50,15 +60,49 @@ class KeyServerCommandServiceTest {
         assertThat(trackingRepo.lastErrorType).isEqualTo("UnsupportedOperationException");
     }
 
+    @Test
+    void forwards_callerIp_from_context_to_recordStarted() {
+        // given:
+        var noopCommand = new KeyServerCommand() {};
+        var trackingRepo = new TrackingBusinessTransactionRepository();
+        KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.empty());
+
+        // when:
+        service.handleCommand(noopCommand, CommandCallerContext.of("192.168.1.0"));
+
+        // then: the anonymized IP must reach recordStarted unchanged
+        assertThat(trackingRepo.lastCallerIp).isEqualTo("192.168.1.0");
+    }
+
+    @Test
+    void records_null_callerIp_when_context_is_empty() {
+        // given:
+        var noopCommand = new KeyServerCommand() {};
+        var trackingRepo = new TrackingBusinessTransactionRepository();
+        KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.empty());
+
+        // when:
+        service.handleCommand(noopCommand, CommandCallerContext.empty());
+
+        // then:
+        assertThat(trackingRepo.lastCallerIp).isNull();
+    }
+
     private static final class TrackingBusinessTransactionRepository implements BusinessTransactionRepository {
         int startedCount;
         int completedCount;
         int failedCount;
+
+        @Nullable
+        String lastCallerIp;
+
+        @Nullable
         String lastErrorType;
 
         @Override
-        public void recordStarted(long btxId, String commandType, String callerIp) {
+        public void recordStarted(long btxId, String commandType, @Nullable String callerIp) {
             startedCount++;
+            lastCallerIp = callerIp;
         }
 
         @Override
@@ -67,7 +111,7 @@ class KeyServerCommandServiceTest {
         }
 
         @Override
-        public void recordFailed(long btxId, String errorType, String errorMessage) {
+        public void recordFailed(long btxId, String errorType, @Nullable String errorMessage) {
             failedCount++;
             lastErrorType = errorType;
         }

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandlerTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.bmarwell.keyserver.application.api.commands.AddKeyToVerificationQueueCommand;
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
 import io.github.bmarwell.keyserver.application.port.notification.VerificationNotificationPort;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
@@ -83,9 +84,9 @@ class AddKeyToVerificationQueueCommandHandlerTest {
     @Test
     void happy_path_enqueues_one_entry_per_uid() throws IOException {
         String keyText = loadTestKey("test-key-with-email.asc");
-        var command = new AddKeyToVerificationQueueCommand(keyText, "192.168.1.0");
+        var command = new AddKeyToVerificationQueueCommand(keyText);
 
-        handler.doExecute(command);
+        handler.doExecute(command, CommandCallerContext.empty());
 
         // The test key has one UID: "Test Key <testkey@example.com>"
         assertThat(fakeRepo.received).hasSize(1);
@@ -96,9 +97,9 @@ class AddKeyToVerificationQueueCommandHandlerTest {
     @Test
     void happy_path_notifies_once_per_uid() throws IOException {
         String keyText = loadTestKey("test-key-with-email.asc");
-        var command = new AddKeyToVerificationQueueCommand(keyText, "10.0.0.0");
+        var command = new AddKeyToVerificationQueueCommand(keyText);
 
-        handler.doExecute(command);
+        handler.doExecute(command, CommandCallerContext.empty());
 
         assertThat(fakeNotification.received).hasSize(1);
         FakeNotificationPort.Notification note = fakeNotification.received.getFirst();
@@ -108,25 +109,28 @@ class AddKeyToVerificationQueueCommandHandlerTest {
 
     @Test
     void rejects_null_key_text() {
-        var command = new AddKeyToVerificationQueueCommand(null, "10.0.0.0");
+        var command = new AddKeyToVerificationQueueCommand(null);
 
-        assertThatThrownBy(() -> handler.doExecute(command)).isInstanceOf(KeyParsingException.class);
+        assertThatThrownBy(() -> handler.doExecute(command, CommandCallerContext.empty()))
+                .isInstanceOf(KeyParsingException.class);
         assertThat(fakeRepo.received).isEmpty();
     }
 
     @Test
     void rejects_blank_key_text() {
-        var command = new AddKeyToVerificationQueueCommand("   ", "10.0.0.0");
+        var command = new AddKeyToVerificationQueueCommand("   ");
 
-        assertThatThrownBy(() -> handler.doExecute(command)).isInstanceOf(KeyParsingException.class);
+        assertThatThrownBy(() -> handler.doExecute(command, CommandCallerContext.empty()))
+                .isInstanceOf(KeyParsingException.class);
         assertThat(fakeRepo.received).isEmpty();
     }
 
     @Test
     void rejects_garbage_key_text() {
-        var command = new AddKeyToVerificationQueueCommand("not a pgp key", "10.0.0.0");
+        var command = new AddKeyToVerificationQueueCommand("not a pgp key");
 
-        assertThatThrownBy(() -> handler.doExecute(command)).isInstanceOf(KeyParsingException.class);
+        assertThatThrownBy(() -> handler.doExecute(command, CommandCallerContext.empty()))
+                .isInstanceOf(KeyParsingException.class);
         assertThat(fakeRepo.received).isEmpty();
         assertThat(fakeNotification.received).isEmpty();
     }
@@ -134,9 +138,9 @@ class AddKeyToVerificationQueueCommandHandlerTest {
     @Test
     void verification_uri_contains_tsid_of_enqueued_entry() throws IOException {
         String keyText = loadTestKey("test-key-with-email.asc");
-        var command = new AddKeyToVerificationQueueCommand(keyText, "10.0.0.0");
+        var command = new AddKeyToVerificationQueueCommand(keyText);
 
-        handler.doExecute(command);
+        handler.doExecute(command, CommandCallerContext.empty());
 
         String expectedTsidStr = Long.toUnsignedString(1000L); // first ID assigned by fake repo
         assertThat(fakeNotification.received.getFirst().verificationUri().toString())

--- a/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/BusinessTransactionRepository.java
+++ b/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/BusinessTransactionRepository.java
@@ -15,6 +15,8 @@
  */
 package io.github.bmarwell.keyserver.application.port.repository;
 
+import org.jspecify.annotations.Nullable;
+
 /// Outbound port for business-transaction lifecycle persistence.
 ///
 /// All implementations must use `@Transactional(REQUIRES_NEW)` so that
@@ -28,7 +30,7 @@ public interface BusinessTransactionRepository {
     /// @param btxId       TSID assigned by the command service
     /// @param commandType simple class name of the command
     /// @param callerIp    remote address of the HTTP client, or `null`
-    void recordStarted(long btxId, String commandType, String callerIp);
+    void recordStarted(long btxId, String commandType, @Nullable String callerIp);
 
     /// Updates the row to state `COMPLETED` and sets `completed_at`.
     void recordCompleted(long btxId);

--- a/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/BusinessTransactionRepository.java
+++ b/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/BusinessTransactionRepository.java
@@ -40,5 +40,5 @@ public interface BusinessTransactionRepository {
     ///
     /// @param errorType    simple class name of the thrown exception
     /// @param errorMessage `Exception.getMessage()`, may be `null`
-    void recordFailed(long btxId, String errorType, String errorMessage);
+    void recordFailed(long btxId, String errorType, @Nullable String errorMessage);
 }

--- a/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/package-info.java
+++ b/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Secondary outbound ports for repository access.
+///
+/// All types in this package are non-null by default (jspecify `@NullMarked`).
+/// Parameters that may be `null` are explicitly annotated with
+/// {@link org.jspecify.annotations.Nullable}.
+@NullMarked
+package io.github.bmarwell.keyserver.application.port.repository;
+
+import org.jspecify.annotations.NullMarked;

--- a/docs/implementation-plan.adoc
+++ b/docs/implementation-plan.adoc
@@ -383,39 +383,45 @@ Each mapper must:
 === 5.1 Current State
 
 `KeyServerCommandService` dispatches commands via an async virtual-thread executor.
-The inner `dispatch()` method carries `@Transactional` so the handler's DAO calls run
-in a single JTA transaction.  BTX lifecycle writes (`recordStarted`, `recordCompleted`,
-`recordFailed`) use `REQUIRES_NEW` so they survive a handler rollback.
+The actual handler invocation is delegated to `TransactionalCommandDispatcher` — a
+separate `@ApplicationScoped` CDI bean — so the `@Transactional` annotation is
+applied through the CDI proxy rather than bypassed by same-bean self-invocation.
+Handler DAO calls therefore run in a single JTA `REQUIRED` transaction.  BTX
+lifecycle writes (`recordStarted`, `recordCompleted`, `recordFailed`) use
+`REQUIRES_NEW` so they survive a handler rollback.
 
 === 5.2 Target State
 
-The current implementation already achieves the target.  The `dispatch()` method in
-`KeyServerCommandService` is annotated `@Transactional` (joining REQUIRED).  Each BTX
-write uses REQUIRES_NEW.  Future refinements:
+The current implementation already achieves the target:
 
-* The caller IP carried in the command should be forwarded to `recordStarted()` —
-  see §8.7.
+* `dispatch()` lives in `TransactionalCommandDispatcher` (separate bean), so
+  `@Transactional` fires correctly through the CDI proxy.
+* Each BTX write uses `REQUIRES_NEW`.
+* ✅ The anonymized caller IP is forwarded to `recordStarted()` via `CommandCallerContext`
+  (see §8.7).
 * A `fingerprint` field on `business_transactions` should be populated once the
   handler can extract it (post-parse).
 
 === 5.3 Audit Log Integration
 
 BTX rows serve as the audit log via the `BusinessTransactionRepository` port.
-The `KeyServerCommandService` wraps every handler call:
+`KeyServerCommandService` wraps every handler call in the following pattern:
 
 [source,java]
 ----
+btxRepository.recordStarted(btxId, commandType, callerContext.anonymizedCallerIp());
+btxContext.initialize(btxId);
 try {
-    result = handler.execute(command);
-    auditLogService.recordSuccess(command, correlationId, fingerprint);
-} catch (KeyServerException ex) {
-    auditLogService.recordFailure(command, correlationId, ex);
-    throw ex;
+    dispatcher.dispatch(command, callerContext);  // @Transactional in separate bean
+    btxRepository.recordCompleted(btxId);
+} catch (Exception ex) {
+    btxRepository.recordFailed(btxId, ex.getClass().getSimpleName(), ex.getMessage());
 }
 ----
 
-`AuditLogService` (port in `application-ports`) is implemented by a JPA adapter
-in `repository`.  Its write always uses `REQUIRES_NEW` so it survives a rollback.
+`BusinessTransactionRepository` (port in `application-ports`) is implemented by
+`PersistentBusinessTransactionRepository` in `repository`.  Every write uses
+`REQUIRES_NEW` so it survives a rollback.
 
 == 6. What Needs to Change Per Module
 
@@ -636,14 +642,17 @@ the handler's stack without any explicit parameter threading.
 
 The client IP address is captured and anonymized in the primary adapter
 (`AddEndpoint`) before the command is constructed.  The anonymized value is
-carried in the command record (`AddKeyToVerificationQueueCommand.anonymizedClientIp`).
+carried in a `CommandCallerContext` that travels alongside the command — it is
+**not** a field on the command record itself.
 
-`KeyServerCommand` exposes a `default Optional<String> callerIp()` method that
-returns `Optional.empty()`.  `AddKeyToVerificationQueueCommand` overrides it to
-return the anonymized IP.  `KeyServerCommandService.handleCommand()` calls
-`command.callerIp().orElse(null)` and passes the result to
-`BusinessTransactionRepository.recordStarted()`, wiring the anonymized IP into
-the BTX audit row without any explicit parameter threading through the handler.
+`AddEndpoint` calls `IpAnonymizer.anonymize(remoteAddr)`, wraps the result in
+`CommandCallerContext.of(anonymizedIp)`, and passes both the command and the
+context to `CommandService.handleCommand(command, callerContext)`.
+`KeyServerCommandService` extracts `callerContext.anonymizedCallerIp()` and
+passes it to `BusinessTransactionRepository.recordStarted()`, wiring the
+anonymized IP into the BTX audit row.  The context is also forwarded through
+`TransactionalCommandDispatcher` to each handler's `execute()` method in case a
+handler needs it in the future.
 
 Rules:
 

--- a/docs/implementation-plan.adoc
+++ b/docs/implementation-plan.adoc
@@ -382,29 +382,26 @@ Each mapper must:
 
 === 5.1 Current State
 
-`PersistentKeyQueueRepositoryService` carries `@Transactional`.  The command
-handlers and `KeyServerCommandService` do not.  This means the boundary is too
-low: only the DAO call is in a transaction, not the full parse-validate-persist
-flow.
+`KeyServerCommandService` dispatches commands via an async virtual-thread executor.
+The inner `dispatch()` method carries `@Transactional` so the handler's DAO calls run
+in a single JTA transaction.  BTX lifecycle writes (`recordStarted`, `recordCompleted`,
+`recordFailed`) use `REQUIRES_NEW` so they survive a handler rollback.
 
 === 5.2 Target State
 
-`KeyServerCommandService.handleCommand()` should be annotated `@Transactional`
-so the entire command lifecycle (parse, validate, persist, enqueue) is one atomic
-unit.
+The current implementation already achieves the target.  The `dispatch()` method in
+`KeyServerCommandService` is annotated `@Transactional` (joining REQUIRED).  Each BTX
+write uses REQUIRES_NEW.  Future refinements:
 
-* On success: the DAO write and the audit log entry commit together.
-* On failure: the main transaction rolls back, but the audit log write should
-  succeed.  Use a _separate_ transaction for the audit log entry
-  (`@Transactional(Transactional.TxType.REQUIRES_NEW)` on an `AuditLogService`).
-
-The `PersistentKeyQueueRepositoryService` can keep its `@Transactional` as a
-safety net but becomes effectively `MANDATORY` (the transaction is already open).
+* The caller IP carried in the command should be forwarded to `recordStarted()` —
+  see §8.7.
+* A `fingerprint` field on `business_transactions` should be populated once the
+  handler can extract it (post-parse).
 
 === 5.3 Audit Log Integration
 
-The `CommandService` should inject an `AuditLogService` and wrap every handler
-invocation:
+BTX rows serve as the audit log via the `BusinessTransactionRepository` port.
+The `KeyServerCommandService` wraps every handler call:
 
 [source,java]
 ----
@@ -440,41 +437,32 @@ in `repository`.  Its write always uses `REQUIRES_NEW` so it survives a rollback
 
 === 6.3 `application/application-core`
 
-* Annotate `KeyServerCommandService.handleCommand()` with `@Transactional`.
-* Inject `AuditLogService` and wrap handler calls (see §5.3).
-* Add `KeyServerQueryService` for read-only lookups (no `@Transactional` write
-  semantics needed — `@Transactional(READ_ONLY)` is sufficient).
-* Complete `AddKeyToVerificationQueueCommandHandler`:
-  - Parse armored input via Bouncy Castle.
-  - Validate: reject expired primary key, reject revoked primary key, drop UIDs
-    without email address, drop UIDs that are revoked or expired.
-  - For each remaining UID, enqueue a verification queue entry.
-  - Return a typed response indicating how many UIDs were queued.
+* ✅ `KeyServerCommandService.handleCommand()` is async (`@Asynchronous`, virtual threads);
+  `dispatch()` carries `@Transactional`.
+* ✅ BTX lifecycle wiring complete.
+* ✅ `AddKeyToVerificationQueueCommandHandler` implemented.
+* Add `KeyServerQueryService` for read-only lookups (`@Transactional(READ_ONLY)`).
 
 === 6.4 `application/application-ports`
 
-* Add `AuditLogPort` (write audit entries).
-* Expand `KeyVerificationQueueDao` with richer parameters matching the new
-  schema.
-* Add `KeyDao` (replaces stub `KeyRepository`) with methods for fingerprint/
-  keyid lookup and insert.
-* Add `UidDao` for UID-level reads needed by `op=index`.
+* ✅ `BusinessTransactionRepository` — BTX lifecycle port (replaces the former `AuditLogPort` idea).
+* ✅ `VerificationQueueRepository` — replaces the former `KeyVerificationQueueDao`.
+* Add `KeyRepository` (replaces stub) with methods for fingerprint/key-ID lookup and insert.
+* Add `UidRepository` for UID-level reads needed by `op=index`.
 
 === 6.5 `repository`
 
-* Implement JPA entities for: `KeyEntity`, `UidEntity`, `VerificationQueueEntity`,
-  `AuditLogEntity`.
-* Implement DAOs.
-* Add Flyway migrations: `V003__expand-keys.sql`, `V004__create-uids.sql`,
-  `V005__create-verification-queue.sql`, `V006__create-audit-log.sql`.
-* Enable `pgcrypto` extension is no longer needed — PKs use TSID (application-assigned `BIGINT`).
+* ✅ `BusinessTransactionEntity` + `PersistentBusinessTransactionRepository`.
+* ✅ `VerificationQueueEntity` + `JpaVerificationQueueRepository`.
+* Add JPA entities: `KeyEntity`, `UidEntity`.
+* Add Flyway migrations for the new tables (see §2).
 
 === 6.6 `web/openpgp-keyserver-protocol`
 
-* `AddEndpoint`: accept `application/x-www-form-urlencoded`, read `keytext`
-  form parameter.
-* `LookupEndpoint`: implement `op=index` and `op=vindex` with
-  machine-readable output.  Honor `options=mr` and `exact=on`.
+* ✅ `AddEndpoint`: `application/x-www-form-urlencoded`, `keytext` form parameter,
+  IP anonymization via `IpAnonymizer`.
+* `LookupEndpoint`: implement `op=index` and `op=vindex` with machine-readable
+  output.  Honor `options=mr` and `exact=on`.
 * Add `KeyServerExceptionMapper` implementing `ExceptionMapper<KeyServerException>`.
 * Add `InvalidKeyIdExceptionMapper` for the `common/ids` parsing error.
 
@@ -497,9 +485,9 @@ in `repository`.  Its write always uses `REQUIRES_NEW` so it survives a rollback
 * *Synchronization*: Multi-keyserver sync is out of scope for now.  The
   `RepositoryName` value object is in place but the sync protocol is not planned.
 
-== 7. Business Transactions (BTX)
+== 8. Business Transactions (BTX)
 
-=== 7.1 Motivation
+=== 8.1 Motivation
 
 Every write command (add key, verify UID, revoke key) must be traceable end-to-end
 so that administrators can answer questions like:
@@ -514,7 +502,7 @@ from entry to final state, survives JTA rollbacks (it writes its own status in a
 separate JTA transaction), and is stored permanently in the `business_transactions`
 table for audit purposes.
 
-=== 7.2 Business Transaction Table
+=== 8.2 Business Transaction Table
 
 [source,sql]
 ----
@@ -532,7 +520,7 @@ CREATE TABLE business_transactions (
 
 The `audit_log` table gains a non-nullable foreign key `btx_id BIGINT REFERENCES business_transactions(id)`.
 
-=== 7.3 BTX ID Strategy
+=== 8.3 BTX ID Strategy
 
 BTX IDs use the same TSID approach as `verification_queue`, but via a *node-aware*
 `TsidFactory` rather than `TSID.fast()`.
@@ -563,7 +551,7 @@ A CDI `@ApplicationScoped` producer creates the `TsidFactory` once at startup,
 reading `TSID_NODE` from the environment (or falling back to 0).  All components
 that need a TSID inject the factory rather than calling `TSID.fast()`.
 
-=== 7.4 Asynchronous Command Execution
+=== 8.4 Asynchronous Command Execution
 
 `KeyServerCommandService.handleCommand()` is annotated with
 `@ManagedExecutorDefinition` (Jakarta Concurrency 3.1) to define a dedicated
@@ -600,7 +588,7 @@ plain `Response` (synchronous); they call `handleCommand()` then return
 `202 Accepted` immediately without any `CompletableFuture` or `CompletionStage`
 in their signatures.
 
-=== 7.5 BTX Lifecycle Within handleCommand()
+=== 8.5 BTX Lifecycle Within handleCommand()
 
 [source]
 ----
@@ -620,7 +608,7 @@ Jakarta Concurrency 3.1 propagates the CDI request context to the async thread,
 so the `@RequestScoped` `BusinessTransactionContext` bean is available throughout
 the handler's stack without any explicit parameter threading.
 
-=== 7.6 Modules Affected
+=== 8.6 Modules Affected
 
 [cols="1,3"]
 |===
@@ -644,17 +632,18 @@ the handler's stack without any explicit parameter threading.
 |Resource methods return plain `Response` (synchronous, `202 Accepted`)
 |===
 
-=== 7.7 Client IP and Audit Trail
+=== 8.7 Client IP and Audit Trail
 
 The client IP address is captured and anonymized in the primary adapter
 (`AddEndpoint`) before the command is constructed.  The anonymized value is
-carried in the command record (`AddKeyToVerificationQueueCommand.anonymizedClientIp`)
-for future wiring into the BTX audit row.
+carried in the command record (`AddKeyToVerificationQueueCommand.anonymizedClientIp`).
 
-Once `BusinessTransactionRepository.recordStarted()` is extended to accept
-optional metadata, the anonymized IP should be written there so administrators
-can correlate submissions with network-level events without ever persisting
-a raw client IP.
+`KeyServerCommand` exposes a `default Optional<String> callerIp()` method that
+returns `Optional.empty()`.  `AddKeyToVerificationQueueCommand` overrides it to
+return the anonymized IP.  `KeyServerCommandService.handleCommand()` calls
+`command.callerIp().orElse(null)` and passes the result to
+`BusinessTransactionRepository.recordStarted()`, wiring the anonymized IP into
+the BTX audit row without any explicit parameter threading through the handler.
 
 Rules:
 
@@ -665,7 +654,7 @@ Rules:
   headers.  Configure the proxy to strip and re-add those headers at the network
   edge if needed.
 
-== 8. Verification Notification (First Iteration: Log Only)
+== 9. Verification Notification (First Iteration: Log Only)
 
 The first iteration uses `LoggingVerificationNotificationAdapter` to deliver the
 verification URI.  This deliberately logs the full URI (which is a bearer token)

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- 3rd party dependencies -->
+    <jspecify.version>1.0.0</jspecify.version>
     <immutables-value.version>2.10.0</immutables-value.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <hypersistence-tsid.version>2.1.4</hypersistence-tsid.version>
@@ -108,6 +109,13 @@
         <artifactId>microprofile-openapi-api</artifactId>
         <version>4.1.1</version>
         <scope>provided</scope>
+      </dependency>
+
+      <!-- nullability -->
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>${jspecify.version}</version>
       </dependency>
 
       <!-- 3rd-party -->
@@ -187,6 +195,11 @@
 
   <!-- forced dependencies -->
   <dependencies>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/PersistentBusinessTransactionRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/PersistentBusinessTransactionRepository.java
@@ -21,6 +21,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jspecify.annotations.Nullable;
 
 /// JPA implementation of `BusinessTransactionRepository`.
 ///
@@ -34,7 +35,7 @@ public class PersistentBusinessTransactionRepository extends BaseRepository impl
 
     @Override
     @Transactional(Transactional.TxType.REQUIRES_NEW)
-    public void recordStarted(long btxId, String commandType, String callerIp) {
+    public void recordStarted(long btxId, String commandType, @Nullable String callerIp) {
         var entity = BusinessTransactionEntity.started(btxId, commandType, callerIp);
         getEntityManager().persist(entity);
         LOG.log(Level.FINE, "BTX {0} STARTED [{1}]", new Object[] {btxId, commandType});

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/PersistentBusinessTransactionRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/PersistentBusinessTransactionRepository.java
@@ -53,7 +53,7 @@ public class PersistentBusinessTransactionRepository extends BaseRepository impl
 
     @Override
     @Transactional(Transactional.TxType.REQUIRES_NEW)
-    public void recordFailed(long btxId, String errorType, String errorMessage) {
+    public void recordFailed(long btxId, String errorType, @Nullable String errorMessage) {
         BusinessTransactionEntity entity = getEntityManager().find(BusinessTransactionEntity.class, btxId);
         if (entity != null) {
             entity.markFailed(errorType, errorMessage);

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/AuditLogEntity.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/AuditLogEntity.java
@@ -23,6 +23,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 /// JPA entity for the `audit_log` table.
 /// Every command dispatch writes one row regardless of outcome.
@@ -54,10 +55,10 @@ public class AuditLogEntity {
 
     /// Absent when the fingerprint could not be extracted from malformed input.
     @Column(name = "fingerprint", updatable = false)
-    private String fingerprint;
+    private @Nullable String fingerprint;
 
     @Column(name = "request_ip", updatable = false)
-    private String requestIp;
+    private @Nullable String requestIp;
 
     @Column(name = "occurred_at", nullable = false, updatable = false)
     private OffsetDateTime occurredAt;
@@ -66,14 +67,14 @@ public class AuditLogEntity {
     private String result;
 
     @Column(name = "failure_type", updatable = false)
-    private String failureType;
+    private @Nullable String failureType;
 
     @Column(name = "failure_message", updatable = false)
-    private String failureMessage;
+    private @Nullable String failureMessage;
 
     protected AuditLogEntity() {}
 
-    private AuditLogEntity(long btxId, String commandType, String requestIp, String fingerprint) {
+    private AuditLogEntity(long btxId, String commandType, @Nullable String requestIp, @Nullable String fingerprint) {
         this.btxId = btxId;
         this.commandType = commandType;
         this.requestIp = requestIp;
@@ -81,7 +82,8 @@ public class AuditLogEntity {
         this.occurredAt = OffsetDateTime.now();
     }
 
-    public static AuditLogEntity success(long btxId, String commandType, String requestIp, String fingerprint) {
+    public static AuditLogEntity success(
+            long btxId, String commandType, @Nullable String requestIp, @Nullable String fingerprint) {
         var entry = new AuditLogEntity(btxId, commandType, requestIp, fingerprint);
         entry.result = "SUCCESS";
         return entry;
@@ -90,10 +92,10 @@ public class AuditLogEntity {
     public static AuditLogEntity failure(
             long btxId,
             String commandType,
-            String requestIp,
-            String fingerprint,
+            @Nullable String requestIp,
+            @Nullable String fingerprint,
             String failureType,
-            String failureMessage) {
+            @Nullable String failureMessage) {
         var entry = new AuditLogEntity(btxId, commandType, requestIp, fingerprint);
         entry.result = "FAILURE";
         entry.failureType = failureType;

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/BusinessTransactionEntity.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/BusinessTransactionEntity.java
@@ -102,7 +102,7 @@ public class BusinessTransactionEntity {
         this.completedAt = OffsetDateTime.now();
     }
 
-    public void markFailed(String errorType, String errorMessage) {
+    public void markFailed(String errorType, @Nullable String errorMessage) {
         this.state = BusinessTransactionState.FAILED;
         this.completedAt = OffsetDateTime.now();
         this.errorType = errorType;

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/BusinessTransactionEntity.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/BusinessTransactionEntity.java
@@ -24,6 +24,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 /// JPA entity for the `business_transactions` table.
 ///
@@ -52,10 +53,10 @@ public class BusinessTransactionEntity {
     private String commandType;
 
     @Column(name = "fingerprint")
-    private String fingerprint;
+    private @Nullable String fingerprint;
 
     @Column(name = "caller_ip")
-    private String callerIp;
+    private @Nullable String callerIp;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "state", nullable = false)
@@ -65,13 +66,13 @@ public class BusinessTransactionEntity {
     private OffsetDateTime startedAt;
 
     @Column(name = "completed_at")
-    private OffsetDateTime completedAt;
+    private @Nullable OffsetDateTime completedAt;
 
     @Column(name = "error_type")
-    private String errorType;
+    private @Nullable String errorType;
 
     @Column(name = "error_message")
-    private String errorMessage;
+    private @Nullable String errorMessage;
 
     protected BusinessTransactionEntity() {}
 
@@ -87,7 +88,7 @@ public class BusinessTransactionEntity {
     /// Callers are responsible for supplying a TSID from the shared node-aware
     /// `TsidFactory` — never from `TSID.fast()` — to guarantee uniqueness
     /// across all server instances.
-    public static BusinessTransactionEntity started(long tsid, String commandType, String callerIp) {
+    public static BusinessTransactionEntity started(long tsid, String commandType, @Nullable String callerIp) {
         var entity = new BusinessTransactionEntity();
         entity.id = tsid;
         entity.commandType = commandType;

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/package-info.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// JPA entity classes for the keyserver persistence layer.
+///
+/// All types in this package are non-null by default (jspecify `@NullMarked`).
+/// Optional / database-nullable columns are annotated with
+/// {@link org.jspecify.annotations.Nullable} on the corresponding field and
+/// every method parameter that accepts a `null` value.
+@NullMarked
+package io.github.bmarwell.keyserver.repository.entity;
+
+import org.jspecify.annotations.NullMarked;

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/package-info.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Secondary adapters implementing repository outbound ports.
+///
+/// All types in this package are non-null by default (jspecify `@NullMarked`).
+/// Parameters that may be `null` are explicitly annotated with
+/// {@link org.jspecify.annotations.Nullable}.
+@NullMarked
+package io.github.bmarwell.keyserver.repository;
+
+import org.jspecify.annotations.NullMarked;

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/AddEndpoint.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/AddEndpoint.java
@@ -17,6 +17,7 @@ package io.github.bmarwell.keyserver.web.pks;
 
 import io.github.bmarwell.keyserver.application.api.CommandService;
 import io.github.bmarwell.keyserver.application.api.commands.AddKeyToVerificationQueueCommand;
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.common.ids.IpAnonymizer;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
@@ -57,8 +58,9 @@ public class AddEndpoint {
     public Response addKey(@RequestBody @FormParam("keytext") String keyText) {
         String rawIp = httpServletRequest.getRemoteAddr();
         String anonymizedIp = IpAnonymizer.anonymize(rawIp);
-        var command = new AddKeyToVerificationQueueCommand(keyText, anonymizedIp);
-        commandService.handleCommand(command);
+        var command = new AddKeyToVerificationQueueCommand(keyText);
+        var callerCtx = CommandCallerContext.of(anonymizedIp);
+        commandService.handleCommand(command, callerCtx);
         return Response.accepted().build();
     }
 


### PR DESCRIPTION
## Changes

### feat: CommandCallerContext — separate caller metadata from command records
- New `CommandCallerContext` record carries `@Nullable String anonymizedCallerIp` alongside commands
- `KeyServerCommand` reverted to a pure marker interface (no `callerIp()` default method)
- `AddKeyToVerificationQueueCommand` reduced to `record(String keyText)` — no IP field
- `CommandService.handleCommand(T cmd, CommandCallerContext callerContext)` now takes an explicit context param
- `CommandHandler.execute()` and `AbstractKeyServerCommandHandler.doExecute()` carry `CommandCallerContext` through all layers
- `AddEndpoint` builds `CommandCallerContext.of(anonymizedIp)` and passes it alongside the command

Full chain: `AddEndpoint → IpAnonymizer → CommandCallerContext → handleCommand() → recordStarted() → business_transactions.caller_ip`

### fix: extract @Transactional dispatch to separate CDI bean
- CDI interceptors do not fire on private self-invocations (proxy bypass)
- Extracted `TransactionalCommandDispatcher` (`@ApplicationScoped`): holds the `@Transactional dispatch()` method so the JTA boundary fires correctly through the CDI proxy
- `KeyServerCommandService` now injects `TransactionalCommandDispatcher` instead of containing a private dispatch method

### feat: jspecify 1.0.0 nullability annotations
- `@NullMarked` package-info in `commands`, `port.repository`, `repository`, `repository.entity`
- `@Nullable` on: `CommandCallerContext.anonymizedCallerIp`, `AddKeyToVerificationQueueCommand.keyText`, `callerIp` params in `BusinessTransactionRepository` / entity, `errorMessage` in `recordFailed` / `markFailed`, nullable entity fields

### test: verify callerIp wiring
- Two new tests in `KeyServerCommandServiceTest`: verify that a non-empty `CommandCallerContext` reaches `recordStarted()` and that `empty()` sends null

### docs: fix implementation-plan.adoc
- §5.1/5.2/5.3: updated for two-bean (`TransactionalCommandDispatcher`) pattern
- §8.7: updated to describe `CommandCallerContext`-based wiring (not the old `callerIp()` approach)