### PR TITLE
feat: VerifyUID flow, JpaKeyRepository, HKP LookupEndpoint

### DIFF
--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/KeyRepositoryService.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/KeyRepositoryService.java
@@ -28,4 +28,16 @@ public interface KeyRepositoryService {
     void getKeyByRepoAndKeyId(RepositoryName repoName, KeyId keyId);
 
     Optional<PgpPublicKey> getKeyByKeyId(KeyId keyId);
+
+    /// Looks up an ASCII-armored public-key block by HKP search string.
+    ///
+    /// The `search` parameter is the raw value of the HKP `search` query parameter.
+    /// Supported formats: `0x<fingerprint>`, `0x<keyid>`, email address, and (when
+    /// `exactMatch` is false) UID substring.
+    ///
+    /// Returns the armored key block for the first matching key, or empty if none found.
+    ///
+    /// @param search     HKP search string
+    /// @param exactMatch if true, only exact fingerprint or email matches are returned
+    Optional<String> getArmoredKeyBySearch(String search, boolean exactMatch);
 }

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/VerifyUidCommand.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/commands/VerifyUidCommand.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.keyserver.application.api.commands;
+
+/// Command issued when an owner clicks a verification link to confirm control
+/// of an email address associated with a submitted PGP key.
+///
+/// The {@code token} is the TSID of the verification-queue entry, encoded as
+/// an unsigned decimal string (the same format embedded in the `/verify/{token}`
+/// URI).  The handler is responsible for parsing it back to a `long`.
+///
+/// Caller metadata travels in the accompanying {@link CommandCallerContext}
+/// as with all other commands.
+public record VerifyUidCommand(String token) implements KeyServerCommand {}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/ex/KeyValidationException.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/ex/KeyValidationException.java
@@ -21,7 +21,11 @@ import java.util.Optional;
 /// Base for exceptions raised when a key is structurally valid but fails
 /// business-level validation rules (expired, revoked, no usable UIDs, …).
 public abstract sealed class KeyValidationException extends KeyServerException
-        permits KeyExpiredException, KeyRevokedException, NoVerifiableUidException, InvalidAlgorithmException {
+        permits KeyExpiredException,
+                KeyRevokedException,
+                NoVerifiableUidException,
+                InvalidAlgorithmException,
+                TooManyVerifiableUidsException {
 
     protected KeyValidationException(String message, Optional<KeyFingerprint> fingerprint) {
         super(message, fingerprint);

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/ex/TooManyVerifiableUidsException.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/ex/TooManyVerifiableUidsException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.keyserver.application.api.ex;
+
+import java.util.Optional;
+
+/// Thrown when a submitted key carries more email-bearing UIDs than the server
+/// is willing to process.
+///
+/// ## Rationale
+///
+/// The 2019 SKS keyserver poisoning attack demonstrated that accepting an
+/// unbounded number of UIDs per key enables a trivial denial-of-service: an
+/// attacker uploads a key with tens of thousands of UIDs, overwhelming anything
+/// that tries to process or display it (GnuPG, Thunderbird, Kleopatra, …).
+/// keys.openpgp.org responded by capping at **5** verified email UIDs.
+///
+/// This implementation uses a cap of
+/// {@link
+/// io.github.bmarwell.keyserver.application.core.cmdhandler.AddKeyToVerificationQueueCommandHandler#MAX_EMAIL_UIDS}
+/// (currently 20).  The reasoning:
+///
+/// - Legitimate real-world keys carry 1–3 UIDs (personal, work, alias).
+/// - Power users with many email aliases rarely exceed 10.
+/// - 20 leaves ample headroom while being 50 000× below DoS territory.
+/// - Email-based verification already limits throughput naturally (each UID
+///   requires one outbound email and one user interaction), so the cap mainly
+///   defends against bulk pre-verification resource exhaustion.
+public final class TooManyVerifiableUidsException extends KeyValidationException {
+
+    public TooManyVerifiableUidsException(String message) {
+        super(message, Optional.empty());
+    }
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/PersistentKeyRepositoryService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/PersistentKeyRepositoryService.java
@@ -16,17 +16,23 @@
 package io.github.bmarwell.keyserver.application.core;
 
 import io.github.bmarwell.keyserver.application.api.KeyRepositoryService;
+import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
 import io.github.bmarwell.keyserver.common.ids.KeyId;
 import io.github.bmarwell.keyserver.common.ids.PgpPublicKey;
 import io.github.bmarwell.keyserver.common.ids.RepositoryName;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
+import jakarta.inject.Inject;
 import java.io.Serializable;
 import java.util.Optional;
 
 @Default
 @ApplicationScoped
 public class PersistentKeyRepositoryService implements KeyRepositoryService, Serializable {
+
+    @Inject
+    KeyRepository keyRepository;
+
     @Override
     public void getKeyByRepoAndKeyId(RepositoryName repoName, KeyId keyId) {
         throw new UnsupportedOperationException("not implemented");
@@ -34,6 +40,16 @@ public class PersistentKeyRepositoryService implements KeyRepositoryService, Ser
 
     @Override
     public Optional<PgpPublicKey> getKeyByKeyId(KeyId keyId) {
-        throw new UnsupportedOperationException("not implemented");
+        return keyRepository.findBySearch(keyId.valueWithHexPrefix(), true).map(result -> result::fingerprint);
+    }
+
+    @Override
+    public Optional<String> getArmoredKeyBySearch(String search, boolean exactMatch) {
+        return keyRepository.findBySearch(search, exactMatch).map(KeyRepository.KeySearchResult::armoredKey);
+    }
+
+    // CDI-friendly setter for unit testing
+    public void setKeyRepository(KeyRepository keyRepository) {
+        this.keyRepository = keyRepository;
     }
 }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
@@ -22,6 +22,7 @@ import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommandRes
 import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
 import io.github.bmarwell.keyserver.application.api.ex.KeyRevokedException;
 import io.github.bmarwell.keyserver.application.api.ex.NoVerifiableUidException;
+import io.github.bmarwell.keyserver.application.api.ex.TooManyVerifiableUidsException;
 import io.github.bmarwell.keyserver.application.port.notification.VerificationNotificationPort;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationRequest;
@@ -77,6 +78,24 @@ public class AddKeyToVerificationQueueCommandHandler
 
     static final int TOKEN_TTL_HOURS = 24;
 
+    /// Maximum number of email-bearing UIDs accepted from a single key submission.
+    ///
+    /// ## Rationale
+    ///
+    /// The 2019 SKS keyserver poisoning attack used keys with tens of thousands of
+    /// UIDs to exhaust memory and CPU in anything that processed them.  keys.openpgp.org
+    /// responded by capping at 5 verified email UIDs.
+    ///
+    /// This implementation uses 20:
+    /// - Legitimate real-world keys carry 1–3 UIDs (personal, work, alias).
+    /// - Power users with many email identities rarely exceed 10.
+    /// - 20 leaves ample headroom while remaining 50 000× below DoS territory.
+    /// - Each UID triggers one outbound email and one user interaction, so the cap
+    ///   also limits resource consumption during the verification flow itself.
+    ///
+    /// @see TooManyVerifiableUidsException
+    static final int MAX_EMAIL_UIDS = 20;
+
     @Inject
     VerificationQueueRepository verificationQueueRepository;
 
@@ -121,6 +140,11 @@ public class AddKeyToVerificationQueueCommandHandler
             throw new NoVerifiableUidException(
                     "Key %s has no UIDs with a verifiable email address".formatted(fingerprintHex(masterKey)));
         }
+        if (emailUids.size() > MAX_EMAIL_UIDS) {
+            throw new TooManyVerifiableUidsException(
+                    "Key %s has %d email UIDs, exceeding the limit of %d — submission rejected as potential DoS"
+                            .formatted(fingerprintHex(masterKey), emailUids.size(), MAX_EMAIL_UIDS));
+        }
 
         String fingerprint = fingerprintHex(masterKey);
         OffsetDateTime expiresAt = OffsetDateTime.now().plusHours(TOKEN_TTL_HOURS);
@@ -145,7 +169,7 @@ public class AddKeyToVerificationQueueCommandHandler
         }
     }
 
-    private List<String> collectEmailUids(PGPPublicKey masterKey) {
+    List<String> collectEmailUids(PGPPublicKey masterKey) {
         List<String> emailUids = new ArrayList<>();
         for (Iterator<String> userIds = masterKey.getUserIDs(); userIds.hasNext(); ) {
             String uid = userIds.next();

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler;
+
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
+import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
+import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommandResponse;
+import io.github.bmarwell.keyserver.application.api.commands.VerifyUidCommand;
+import io.github.bmarwell.keyserver.application.api.ex.TokenExpiredException;
+import io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException;
+import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
+import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
+import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationEntry;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import java.time.OffsetDateTime;
+
+/// Handles {@link VerifyUidCommand} — the action triggered when an owner clicks
+/// the email verification link.
+///
+/// ## Flow
+///
+/// 1. Parse the token string as an unsigned-decimal `long` (the TSID embedded in
+///    the `/verify/{token}` URI).  An unparseable token → {@link TokenInvalidException}.
+/// 2. Look up the verification-queue entry with {@link VerificationQueueRepository#findPendingById}.
+///    Returns empty for both "not found" and "already consumed" cases — both map to
+///    {@link TokenInvalidException} to avoid leaking whether a token ever existed.
+/// 3. Check `expiresAt`: if the token has passed its deadline → {@link TokenExpiredException}.
+/// 4. Mark the entry {@code VERIFIED} so it cannot be replayed.
+/// 5. Publish the verified UID via {@link KeyRepository#publishVerifiedUid}: creates the
+///    key row on first verification, appends the UID on subsequent ones (partial
+///    publishing — a key may be live with one UID while another is still pending).
+///
+/// ## Caller context
+///
+/// The `CommandCallerContext` is threaded through for audit consistency but this
+/// handler does not require the IP directly.
+@RequestScoped
+public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<VerifyUidCommand> {
+
+    @Inject
+    VerificationQueueRepository verificationQueueRepository;
+
+    @Inject
+    KeyRepository keyRepository;
+
+    @Override
+    public <C extends KeyServerCommand> boolean canHandle(C command) {
+        return command instanceof VerifyUidCommand;
+    }
+
+    @Override
+    KeyServerCommandResponse doExecute(VerifyUidCommand command, CommandCallerContext callerContext) {
+        long tokenId = parseToken(command.token());
+
+        VerificationEntry entry = verificationQueueRepository
+                .findPendingById(tokenId)
+                .orElseThrow(() -> new TokenInvalidException(
+                        "Verification token not found or already consumed: " + command.token()));
+
+        if (entry.expiresAt().isBefore(OffsetDateTime.now())) {
+            throw new TokenExpiredException("Verification token has expired for fingerprint " + entry.fingerprint());
+        }
+
+        verificationQueueRepository.markVerified(tokenId);
+        keyRepository.publishVerifiedUid(entry.fingerprint(), entry.uidRaw(), entry.uidEmail(), entry.armoredKey());
+
+        return KeyServerCommandResponse.success();
+    }
+
+    private long parseToken(String token) {
+        try {
+            return Long.parseUnsignedLong(token);
+        } catch (NumberFormatException e) {
+            throw new TokenInvalidException("Verification token is not a valid unsigned integer: " + token);
+        }
+    }
+
+    // CDI-friendly setters for unit testing
+    public void setVerificationQueueRepository(VerificationQueueRepository verificationQueueRepository) {
+        this.verificationQueueRepository = verificationQueueRepository;
+    }
+
+    public void setKeyRepository(KeyRepository keyRepository) {
+        this.keyRepository = keyRepository;
+    }
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
@@ -69,7 +69,11 @@ public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<Ver
         VerificationEntry entry = verificationQueueRepository
                 .findPendingById(tokenId)
                 .orElseThrow(() -> new TokenInvalidException(
-                        "Verification token not found or already consumed: " + command.token()));
+                        // Do not echo the token value into the exception message.
+                        // The message is logged by the exception mapper, and including the token
+                        // would: (a) expose a credential-like value in logs, and (b) enable log
+                        // injection if a caller passes an extremely long or control-char-bearing string.
+                        "Verification token not found or already consumed"));
 
         if (entry.expiresAt().isBefore(OffsetDateTime.now())) {
             throw new TokenExpiredException("Verification token has expired for fingerprint " + entry.fingerprint());
@@ -85,7 +89,9 @@ public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<Ver
         try {
             return Long.parseUnsignedLong(token);
         } catch (NumberFormatException e) {
-            throw new TokenInvalidException("Verification token is not a valid unsigned integer: " + token);
+            // Do not include the raw token in the message — it is attacker-controlled
+            // and could be arbitrarily long or contain control characters (log injection).
+            throw new TokenInvalidException("Verification token is not a valid unsigned integer");
         }
     }
 

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandlerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.github.bmarwell.keyserver.application.api.commands.AddKeyToVerificationQueueCommand;
 import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
+import io.github.bmarwell.keyserver.application.api.ex.TooManyVerifiableUidsException;
 import io.github.bmarwell.keyserver.application.port.notification.VerificationNotificationPort;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationRequest;
@@ -29,7 +30,10 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+import org.bouncycastle.openpgp.PGPPublicKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +49,14 @@ class AddKeyToVerificationQueueCommandHandlerTest {
             received.add(request);
             return counter.getAndIncrement();
         }
+
+        @Override
+        public Optional<VerificationEntry> findPendingById(long tokenId) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void markVerified(long tokenId) {}
     }
 
     /** Fake notification port that records every call. */
@@ -145,5 +157,48 @@ class AddKeyToVerificationQueueCommandHandlerTest {
         String expectedTsidStr = Long.toUnsignedString(1000L); // first ID assigned by fake repo
         assertThat(fakeNotification.received.getFirst().verificationUri().toString())
                 .endsWith(expectedTsidStr);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 6: one million (well, MAX_EMAIL_UIDS + 1) email UIDs → rejected
+    // -----------------------------------------------------------------------
+
+    /**
+     * Subclass that overrides {@code collectEmailUids} to return a synthetic list
+     * of fake email addresses, bypassing the need for a real PGP key with many UIDs.
+     * This tests the DoS guard in isolation from the PGP parsing logic.
+     */
+    static class OverflowingHandler extends AddKeyToVerificationQueueCommandHandler {
+        private final int uidCount;
+
+        OverflowingHandler(int uidCount) {
+            this.uidCount = uidCount;
+        }
+
+        @Override
+        List<String> collectEmailUids(PGPPublicKey masterKey) {
+            return IntStream.range(0, uidCount)
+                    .mapToObj(i -> "user%d@example.com".formatted(i))
+                    .collect(java.util.stream.Collectors.toList());
+        }
+    }
+
+    @Test
+    void scenario6_too_many_email_uids_rejected() throws IOException {
+        int overLimit = AddKeyToVerificationQueueCommandHandler.MAX_EMAIL_UIDS + 1;
+        var overflowHandler = new OverflowingHandler(overLimit);
+        overflowHandler.setVerificationQueueRepository(fakeRepo);
+        overflowHandler.setNotificationPort(fakeNotification);
+
+        String keyText = loadTestKey("test-key-with-email.asc");
+        var command = new AddKeyToVerificationQueueCommand(keyText);
+
+        assertThatThrownBy(() -> overflowHandler.doExecute(command, CommandCallerContext.empty()))
+                .isInstanceOf(TooManyVerifiableUidsException.class)
+                .hasMessageContaining(String.valueOf(overLimit))
+                .hasMessageContaining(String.valueOf(AddKeyToVerificationQueueCommandHandler.MAX_EMAIL_UIDS));
+
+        assertThat(fakeRepo.received).isEmpty();
+        assertThat(fakeNotification.received).isEmpty();
     }
 }

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
@@ -59,6 +59,11 @@ class VerifyUidCommandHandlerTest {
         public void publishVerifiedUid(String fingerprint, String uidRaw, String uidEmail, String armoredKey) {
             published.add(new PublishedUid(fingerprint, uidRaw, uidEmail));
         }
+
+        @Override
+        public Optional<KeySearchResult> findBySearch(String search, boolean exactMatch) {
+            return Optional.empty();
+        }
     }
 
     /**

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
@@ -27,22 +27,27 @@ import io.github.bmarwell.keyserver.application.port.repository.VerificationQueu
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationEntry;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /// Unit tests for {@link VerifyUidCommandHandler}.
 ///
-/// All six verification-flow scenarios are covered here at handler level.
+/// All seven verification-flow scenarios are covered here at handler level.
 /// No database, no CDI container — dependencies are plain fake implementations
 /// wired through setter injection.
 ///
 /// Integration tests with a real Liberty server and PostgreSQL (via Testcontainers)
 /// are planned in the `integration-tests` module and will cover the full HTTP
-/// request → handler → DB roundtrip.
+/// request → handler → DB roundtrip, including the JPA-level concurrency controls
+/// for scenario 7 (concurrent UID publication for the same key).
 class VerifyUidCommandHandlerTest {
 
     // -----------------------------------------------------------------------
@@ -51,9 +56,10 @@ class VerifyUidCommandHandlerTest {
 
     record PublishedUid(String fingerprint, String uidRaw, String uidEmail) {}
 
-    /** Fake key repository that records every publishVerifiedUid call. */
+    /** Fake key repository that records every publishVerifiedUid call. Thread-safe for scenario 7. */
     static class FakeKeyRepository implements KeyRepository {
-        final List<PublishedUid> published = new ArrayList<>();
+        // CopyOnWriteArrayList: safe for concurrent adds without external synchronisation.
+        final List<PublishedUid> published = new CopyOnWriteArrayList<>();
 
         @Override
         public void publishVerifiedUid(String fingerprint, String uidRaw, String uidEmail, String armoredKey) {
@@ -69,13 +75,14 @@ class VerifyUidCommandHandlerTest {
     /**
      * Fake verification-queue repository backed by a simple map.
      * Entries are pre-populated via {@link #put} before the handler is invoked.
+     * Thread-safe for scenario 7: store uses a synchronizedMap, verifiedIds a synchronizedList.
      */
     static class FakeVerificationQueueRepository implements VerificationQueueRepository {
 
         record StoredEntry(VerificationEntry entry, boolean consumed) {}
 
-        final Map<Long, StoredEntry> store = new HashMap<>();
-        final List<Long> verifiedIds = new ArrayList<>();
+        final Map<Long, StoredEntry> store = Collections.synchronizedMap(new HashMap<>());
+        final List<Long> verifiedIds = Collections.synchronizedList(new ArrayList<>());
 
         void put(long id, VerificationEntry entry) {
             store.put(id, new StoredEntry(entry, false));
@@ -257,5 +264,69 @@ class VerifyUidCommandHandlerTest {
                         new VerifyUidCommand(Long.toUnsignedString(9_999L)), CommandCallerContext.empty()))
                 .isInstanceOf(TokenInvalidException.class);
         assertThat(fakeKeys.published).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 7: Two UIDs verified at the exact same time (concurrent publication).
+    //
+    // At the handler level both verifications are independently valid: each token
+    // is distinct and each handler invocation succeeds on its own.  The handler
+    // itself has no race condition — it calls publishVerifiedUid once and returns.
+    //
+    // The race lives in the JPA adapter (JpaKeyRepository): two concurrent
+    // transactions could both see key == null and both attempt a plain INSERT,
+    // causing a constraint violation and losing one UID.  Or both could load the
+    // armored block independently and overwrite each other's UID strip.
+    //
+    // This test verifies the application-layer correctness: both handler invocations
+    // must complete successfully and forward their respective UIDs to the repository.
+    // The JPA-level serialisation (INSERT ON CONFLICT DO NOTHING + PESSIMISTIC_WRITE)
+    // is validated by integration tests in the integration-tests module.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void scenario7_concurrent_uid_verification_both_published() throws Exception {
+        fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+        fakeQueue.put(TOKEN_2, pendingEntry(TOKEN_2, "Alice Work <work@corp.example>", "work@corp.example"));
+
+        // Release both threads at the same instant to maximise overlap.
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+        Thread t1 = new Thread(() -> {
+            try {
+                start.await();
+                handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+            } catch (Throwable t) {
+                errors.add(t);
+            } finally {
+                done.countDown();
+            }
+        });
+        Thread t2 = new Thread(() -> {
+            try {
+                start.await();
+                handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_2)), CommandCallerContext.empty());
+            } catch (Throwable t) {
+                errors.add(t);
+            } finally {
+                done.countDown();
+            }
+        });
+
+        t1.start();
+        t2.start();
+        start.countDown(); // release both simultaneously
+        done.await(5, TimeUnit.SECONDS);
+
+        assertThat(errors).as("no exception during concurrent verification").isEmpty();
+        assertThat(fakeKeys.published)
+                .as("both UIDs must be published — neither lost to a concurrent-write race")
+                .hasSize(2);
+        assertThat(fakeKeys.published)
+                .extracting(PublishedUid::uidEmail)
+                .containsExactlyInAnyOrder("alice@example.com", "work@corp.example");
+        assertThat(fakeQueue.verifiedIds).containsExactlyInAnyOrder(TOKEN_1, TOKEN_2);
     }
 }

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
+import io.github.bmarwell.keyserver.application.api.commands.VerifyUidCommand;
+import io.github.bmarwell.keyserver.application.api.ex.TokenExpiredException;
+import io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException;
+import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
+import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
+import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationEntry;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/// Unit tests for {@link VerifyUidCommandHandler}.
+///
+/// All six verification-flow scenarios are covered here at handler level.
+/// No database, no CDI container — dependencies are plain fake implementations
+/// wired through setter injection.
+///
+/// Integration tests with a real Liberty server and PostgreSQL (via Testcontainers)
+/// are planned in the `integration-tests` module and will cover the full HTTP
+/// request → handler → DB roundtrip.
+class VerifyUidCommandHandlerTest {
+
+    // -----------------------------------------------------------------------
+    // Fakes
+    // -----------------------------------------------------------------------
+
+    record PublishedUid(String fingerprint, String uidRaw, String uidEmail) {}
+
+    /** Fake key repository that records every publishVerifiedUid call. */
+    static class FakeKeyRepository implements KeyRepository {
+        final List<PublishedUid> published = new ArrayList<>();
+
+        @Override
+        public void publishVerifiedUid(String fingerprint, String uidRaw, String uidEmail, String armoredKey) {
+            published.add(new PublishedUid(fingerprint, uidRaw, uidEmail));
+        }
+    }
+
+    /**
+     * Fake verification-queue repository backed by a simple map.
+     * Entries are pre-populated via {@link #put} before the handler is invoked.
+     */
+    static class FakeVerificationQueueRepository implements VerificationQueueRepository {
+
+        record StoredEntry(VerificationEntry entry, boolean consumed) {}
+
+        final Map<Long, StoredEntry> store = new HashMap<>();
+        final List<Long> verifiedIds = new ArrayList<>();
+
+        void put(long id, VerificationEntry entry) {
+            store.put(id, new StoredEntry(entry, false));
+        }
+
+        @Override
+        public long enqueue(VerificationRequest request) {
+            throw new UnsupportedOperationException("not needed in this test");
+        }
+
+        @Override
+        public Optional<VerificationEntry> findPendingById(long tokenId) {
+            StoredEntry stored = store.get(tokenId);
+            if (stored == null || stored.consumed()) {
+                return Optional.empty();
+            }
+            return Optional.of(stored.entry());
+        }
+
+        @Override
+        public void markVerified(long tokenId) {
+            StoredEntry stored = store.get(tokenId);
+            if (stored != null) {
+                store.put(tokenId, new StoredEntry(stored.entry(), true));
+                verifiedIds.add(tokenId);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Fixture helpers
+    // -----------------------------------------------------------------------
+
+    static final String FINGERPRINT = "AABBCCDDEEFF00112233445566778899AABBCCDD";
+    static final String ARMORED_KEY =
+            "-----BEGIN PGP PUBLIC KEY BLOCK-----\n(stub)\n-----END PGP PUBLIC KEY BLOCK-----";
+    static final long TOKEN_1 = 1_000L;
+    static final long TOKEN_2 = 2_000L;
+
+    private VerificationEntry pendingEntry(long id, String uidRaw, String uidEmail) {
+        return new VerificationEntry(
+                id,
+                FINGERPRINT,
+                uidRaw,
+                uidEmail,
+                ARMORED_KEY,
+                OffsetDateTime.now().plusHours(24));
+    }
+
+    private VerificationEntry expiredEntry(long id, String uidRaw, String uidEmail) {
+        return new VerificationEntry(
+                id,
+                FINGERPRINT,
+                uidRaw,
+                uidEmail,
+                ARMORED_KEY,
+                OffsetDateTime.now().minusHours(1));
+    }
+
+    FakeVerificationQueueRepository fakeQueue;
+    FakeKeyRepository fakeKeys;
+    VerifyUidCommandHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        fakeQueue = new FakeVerificationQueueRepository();
+        fakeKeys = new FakeKeyRepository();
+        handler = new VerifyUidCommandHandler();
+        handler.setVerificationQueueRepository(fakeQueue);
+        handler.setKeyRepository(fakeKeys);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 2: one email address, token times out → key never published
+    // -----------------------------------------------------------------------
+
+    @Test
+    void scenario2_expired_token_throws_TokenExpiredException() {
+        fakeQueue.put(TOKEN_1, expiredEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+
+        assertThatThrownBy(() -> handler.doExecute(
+                        new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty()))
+                .isInstanceOf(TokenExpiredException.class);
+
+        assertThat(fakeKeys.published).isEmpty();
+        assertThat(fakeQueue.verifiedIds).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 3: one email address, link clicked → key published
+    // -----------------------------------------------------------------------
+
+    @Test
+    void scenario3_single_email_clicked_publishes_key() {
+        fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+
+        handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+
+        assertThat(fakeKeys.published).hasSize(1);
+        assertThat(fakeKeys.published.getFirst().uidEmail()).isEqualTo("alice@example.com");
+        assertThat(fakeKeys.published.getFirst().fingerprint()).isEqualTo(FINGERPRINT);
+        assertThat(fakeQueue.verifiedIds).containsExactly(TOKEN_1);
+    }
+
+    @Test
+    void scenario3_token_cannot_be_replayed() {
+        fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+
+        // First click succeeds
+        handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+
+        // Second click on the same token → invalid (consumed)
+        assertThatThrownBy(() -> handler.doExecute(
+                        new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty()))
+                .isInstanceOf(TokenInvalidException.class);
+
+        // Key was published only once
+        assertThat(fakeKeys.published).hasSize(1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 4: two email addresses, one clicked, one times out
+    //   → only first UID published; second token expires silently
+    // -----------------------------------------------------------------------
+
+    @Test
+    void scenario4_two_emails_one_clicked_one_expired() {
+        fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+        fakeQueue.put(TOKEN_2, expiredEntry(TOKEN_2, "Alice Work <work@corp.example>", "work@corp.example"));
+
+        // First verification succeeds
+        handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+
+        // Second token has expired
+        assertThatThrownBy(() -> handler.doExecute(
+                        new VerifyUidCommand(Long.toUnsignedString(TOKEN_2)), CommandCallerContext.empty()))
+                .isInstanceOf(TokenExpiredException.class);
+
+        // Only first UID was published
+        assertThat(fakeKeys.published).hasSize(1);
+        assertThat(fakeKeys.published.getFirst().uidEmail()).isEqualTo("alice@example.com");
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 5: two email addresses, both clicked (with delay simulated by
+    //   sequential handler calls) → both UIDs published
+    // -----------------------------------------------------------------------
+
+    @Test
+    void scenario5_two_emails_both_clicked_both_published() {
+        fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+        fakeQueue.put(TOKEN_2, pendingEntry(TOKEN_2, "Alice Work <work@corp.example>", "work@corp.example"));
+
+        handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+        handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_2)), CommandCallerContext.empty());
+
+        assertThat(fakeKeys.published).hasSize(2);
+        assertThat(fakeKeys.published)
+                .extracting(PublishedUid::uidEmail)
+                .containsExactlyInAnyOrder("alice@example.com", "work@corp.example");
+        assertThat(fakeQueue.verifiedIds).containsExactlyInAnyOrder(TOKEN_1, TOKEN_2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Invalid-token edge cases
+    // -----------------------------------------------------------------------
+
+    @Test
+    void garbled_token_string_throws_TokenInvalidException() {
+        assertThatThrownBy(() -> handler.doExecute(new VerifyUidCommand("not-a-number"), CommandCallerContext.empty()))
+                .isInstanceOf(TokenInvalidException.class);
+        assertThat(fakeKeys.published).isEmpty();
+    }
+
+    @Test
+    void unknown_token_throws_TokenInvalidException() {
+        // Nothing in the fake queue
+        assertThatThrownBy(() -> handler.doExecute(
+                        new VerifyUidCommand(Long.toUnsignedString(9_999L)), CommandCallerContext.empty()))
+                .isInstanceOf(TokenInvalidException.class);
+        assertThat(fakeKeys.published).isEmpty();
+    }
+}

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
@@ -318,7 +318,18 @@ class VerifyUidCommandHandlerTest {
         t1.start();
         t2.start();
         start.countDown(); // release both simultaneously
-        done.await(5, TimeUnit.SECONDS);
+
+        // If await returns false the threads did not finish within the deadline.
+        // Interrupt both and join to avoid dangling threads poisoning subsequent tests.
+        boolean completed = done.await(5, TimeUnit.SECONDS);
+        if (!completed) {
+            t1.interrupt();
+            t2.interrupt();
+            t1.join(1_000);
+            t2.join(1_000);
+            org.junit.jupiter.api.Assertions.fail(
+                    "Concurrent verification did not complete within timeout — possible deadlock");
+        }
 
         assertThat(errors).as("no exception during concurrent verification").isEmpty();
         assertThat(fakeKeys.published)

--- a/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/KeyRepository.java
+++ b/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/KeyRepository.java
@@ -15,4 +15,26 @@
  */
 package io.github.bmarwell.keyserver.application.port.repository;
 
-public interface KeyRepository {}
+/// Secondary (outbound) port for the published key store.
+///
+/// Keys become visible through this repository only after at least one UID has
+/// been email-verified.  Each verified UID is added individually; a single key
+/// may be present with one UID and later enriched with additional UIDs as their
+/// owners complete verification.
+public interface KeyRepository {
+
+    /// Publishes a newly verified UID, creating the key record if it does not yet
+    /// exist or appending the UID to an existing key record.
+    ///
+    /// The `armoredKey` provided here is the **full** armored block as submitted by
+    /// the uploader.  The adapter is responsible for stripping unverified UIDs
+    /// before storing and serving the key (privacy-preserving, à la keys.openpgp.org).
+    /// The stored `armored_key` column is updated on each call so the served block
+    /// always reflects all UIDs verified so far.
+    ///
+    /// @param fingerprint hex fingerprint (40 chars for v4, 64 for v5)
+    /// @param uidRaw      raw UID string as it appears in the key packet
+    /// @param uidEmail    email address extracted from the UID
+    /// @param armoredKey  full ASCII-armored public-key block
+    void publishVerifiedUid(String fingerprint, String uidRaw, String uidEmail, String armoredKey);
+}

--- a/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/KeyRepository.java
+++ b/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/KeyRepository.java
@@ -15,6 +15,8 @@
  */
 package io.github.bmarwell.keyserver.application.port.repository;
 
+import java.util.Optional;
+
 /// Secondary (outbound) port for the published key store.
 ///
 /// Keys become visible through this repository only after at least one UID has
@@ -22,6 +24,13 @@ package io.github.bmarwell.keyserver.application.port.repository;
 /// may be present with one UID and later enriched with additional UIDs as their
 /// owners complete verification.
 public interface KeyRepository {
+
+    /// Result type returned by key search queries.
+    ///
+    /// Contains the minimal data required by the HKP `op=get` and `op=index` responses.
+    /// The `armoredKey` field holds only the verified UIDs (privacy-preserving, per
+    /// {@link #publishVerifiedUid} contract).
+    record KeySearchResult(String fingerprint, String armoredKey) {}
 
     /// Publishes a newly verified UID, creating the key record if it does not yet
     /// exist or appending the UID to an existing key record.
@@ -37,4 +46,20 @@ public interface KeyRepository {
     /// @param uidEmail    email address extracted from the UID
     /// @param armoredKey  full ASCII-armored public-key block
     void publishVerifiedUid(String fingerprint, String uidRaw, String uidEmail, String armoredKey);
+
+    /// Searches for a key by fingerprint, key ID, or email address.
+    ///
+    /// The `search` parameter is the raw HKP `search` query string.  Accepted formats:
+    ///
+    /// * `0x<hex>` — fingerprint (40 or 64 chars after prefix) or key ID (8 or 16 chars)
+    /// * `<email>` — exact email address (must contain `@`)
+    /// * other — substring match on UID raw string when `exactMatch` is false; no results
+    ///   when `exactMatch` is true
+    ///
+    /// Returns the first matching key's armored block and fingerprint, or empty if not found.
+    /// Only keys with at least one verified UID are returned.
+    ///
+    /// @param search     HKP search string
+    /// @param exactMatch when true, only exact fingerprint/email matches are returned
+    Optional<KeySearchResult> findBySearch(String search, boolean exactMatch);
 }

--- a/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/VerificationQueueRepository.java
+++ b/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/VerificationQueueRepository.java
@@ -16,6 +16,7 @@
 package io.github.bmarwell.keyserver.application.port.repository;
 
 import java.time.OffsetDateTime;
+import java.util.Optional;
 
 /// Secondary (outbound) port for the verification queue.
 ///
@@ -32,9 +33,38 @@ public interface VerificationQueueRepository {
     record VerificationRequest(
             String fingerprint, String uidRaw, String uidEmail, String armoredKey, OffsetDateTime expiresAt) {}
 
+    /// Snapshot of a verification queue row returned to the application core.
+    ///
+    /// Only rows in state `PENDING` are returned by {@link #findPendingById}; the
+    /// application layer never sees `VERIFIED`, `EXPIRED`, or `REJECTED` entries
+    /// through this result type — the adapter returns {@link Optional#empty()} for
+    /// those states, which the handler maps to `TokenInvalidException`.
+    /// This prevents leaking whether a token ever existed to callers who probe
+    /// already-consumed links.
+    record VerificationEntry(
+            long id, String fingerprint, String uidRaw, String uidEmail, String armoredKey, OffsetDateTime expiresAt) {}
+
     /// Persists a single verification queue entry and returns its TSID.
     ///
     /// @param request the data for this queue entry
     /// @return the TSID (`BIGINT`) assigned to the new row
     long enqueue(VerificationRequest request);
+
+    /// Looks up a verification queue entry by token ID, returning it only if
+    /// its state is `PENDING`.
+    ///
+    /// Returns {@link Optional#empty()} when:
+    /// - no row exists for the given ID, or
+    /// - the row exists but is not in state `PENDING` (already VERIFIED, EXPIRED, or REJECTED).
+    ///
+    /// Callers must **not** distinguish the two empty cases — both yield
+    /// {@link io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException}.
+    Optional<VerificationEntry> findPendingById(long tokenId);
+
+    /// Transitions a `PENDING` queue entry to `VERIFIED`.
+    ///
+    /// Called by the handler after expiry and existence checks pass, immediately
+    /// before the verified UID is published to the key store.  Implementations
+    /// must be idempotent with respect to concurrent calls for the same token.
+    void markVerified(long tokenId);
 }

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -39,6 +39,16 @@
       <artifactId>hypersistence-tsid</artifactId>
     </dependency>
 
+    <!-- BouncyCastle: parse armored key metadata when creating KeyEntity rows -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpg-jdk18on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
@@ -16,6 +16,7 @@
 package io.github.bmarwell.keyserver.repository;
 
 import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
+import io.github.bmarwell.keyserver.application.port.repository.KeyRepository.KeySearchResult;
 import io.github.bmarwell.keyserver.repository.entity.KeyEntity;
 import io.github.bmarwell.keyserver.repository.entity.UidEntity;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -31,6 +32,8 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
@@ -69,6 +72,104 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
             uid.setVerified(true);
             key.addUid(uid);
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Search queries
+    // -------------------------------------------------------------------------
+
+    @Override
+    @Transactional
+    public Optional<KeySearchResult> findBySearch(String search, boolean exactMatch) {
+        if (search == null || search.isBlank()) {
+            return Optional.empty();
+        }
+
+        String normalized = search.strip();
+
+        // Fingerprint or key-ID search: starts with 0x or is all-hex
+        if (normalized.startsWith("0x") || isHexString(normalized)) {
+            return findByKeyIdOrFingerprint(normalized.startsWith("0x") ? normalized.substring(2) : normalized);
+        }
+
+        // Email search
+        if (normalized.contains("@")) {
+            return findByEmail(normalized.toLowerCase(Locale.ROOT), exactMatch);
+        }
+
+        // Fallback: UID substring search (only for non-exact)
+        if (exactMatch) {
+            return Optional.empty();
+        }
+        return findByUidSubstring(normalized);
+    }
+
+    private Optional<KeySearchResult> findByKeyIdOrFingerprint(String hexValue) {
+        String lower = hexValue.toLowerCase(Locale.ROOT);
+        int len = lower.length();
+        if (len == 40 || len == 64) {
+            // Full fingerprint — try uppercase first (as stored by the handler)
+            KeyEntity key = getEntityManager().find(KeyEntity.class, lower.toUpperCase(Locale.ROOT));
+            if (key == null) {
+                key = getEntityManager().find(KeyEntity.class, lower);
+            }
+            return toResult(key);
+        }
+        // Short (8) or long (16) key ID — match via keyid_long suffix
+        String suffix = len == 8 ? "%" + lower : lower;
+        List<KeyEntity> results = getEntityManager()
+                .createQuery("SELECT k FROM KeyEntity k WHERE LOWER(k.keyidLong) LIKE :suffix", KeyEntity.class)
+                .setParameter("suffix", suffix)
+                .setMaxResults(1)
+                .getResultList();
+        return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
+    }
+
+    private Optional<KeySearchResult> findByEmail(String email, boolean exactMatch) {
+        String jpql = exactMatch
+                ? "SELECT DISTINCT k FROM KeyEntity k JOIN k.uids u"
+                        + " WHERE LOWER(u.uidEmail) = :email AND u.verified = true"
+                : "SELECT DISTINCT k FROM KeyEntity k JOIN k.uids u"
+                        + " WHERE LOWER(u.uidEmail) LIKE :email AND u.verified = true";
+        String param = exactMatch ? email : "%" + email + "%";
+        List<KeyEntity> results = getEntityManager()
+                .createQuery(jpql, KeyEntity.class)
+                .setParameter("email", param)
+                .setMaxResults(1)
+                .getResultList();
+        return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
+    }
+
+    private Optional<KeySearchResult> findByUidSubstring(String term) {
+        List<KeyEntity> results = getEntityManager()
+                .createQuery(
+                        "SELECT DISTINCT k FROM KeyEntity k JOIN k.uids u"
+                                + " WHERE LOWER(u.uidRaw) LIKE :term AND u.verified = true",
+                        KeyEntity.class)
+                .setParameter("term", "%" + term.toLowerCase(Locale.ROOT) + "%")
+                .setMaxResults(1)
+                .getResultList();
+        return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
+    }
+
+    private static Optional<KeySearchResult> toResult(KeyEntity key) {
+        if (key == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new KeySearchResult(key.getFingerprint(), key.getArmoredKey()));
+    }
+
+    private static boolean isHexString(String s) {
+        if (s.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     // -------------------------------------------------------------------------

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
@@ -23,6 +23,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.transaction.Transactional;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -30,14 +31,20 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.HexFormat;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+import org.bouncycastle.openpgp.PGPSignature;
 import org.bouncycastle.openpgp.PGPUtil;
 import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
 
@@ -57,16 +64,25 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
         KeyEntity key = getEntityManager().find(KeyEntity.class, fingerprint);
 
         if (key == null) {
-            key = createKeyEntity(fingerprint, armoredKey);
+            // Privacy: strip all UIDs except the one being verified now.
+            // The queued armoredKey is the raw user upload containing ALL UIDs.
+            // We must not publish unverified identities — only serve what the owner
+            // has actively confirmed via the email link.
+            String stripped = stripToVerifiedUids(armoredKey, Set.of(uidRaw));
+            key = createKeyEntity(fingerprint, stripped);
             getEntityManager().persist(key);
         } else {
-            // Update the armored block so it reflects newly verified UIDs (privacy: caller
-            // is responsible for stripping unverified UIDs before passing armoredKey here).
-            updateKey(key, armoredKey);
+            // Build the set of already-verified UIDs plus the new one being confirmed.
+            // Re-strip from the original armored key (which was stored in the queue) so
+            // the stored block always reflects exactly the verified-UID set and nothing more.
+            Set<String> verifiedUids = loadVerifiedUidRaws(fingerprint);
+            verifiedUids.add(uidRaw);
+            String stripped = stripToVerifiedUids(armoredKey, verifiedUids);
+            updateKey(key, stripped);
         }
 
-        // Add the UID if it is not already present (idempotency guard for retries).
-        if (!hasUid(key, uidRaw)) {
+        // Add the UID row if not already present (idempotency guard for retries).
+        if (!hasUid(key.getFingerprint(), uidRaw)) {
             UidEntity uid = new UidEntity(key, uidRaw);
             uid.setUidEmail(uidEmail);
             uid.setVerified(true);
@@ -190,44 +206,123 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
     }
 
     private void updateKey(KeyEntity key, String armoredKey) {
-        // Use reflection-friendly setter approach: the entity exposes setArmoredKey and
-        // setMtime via package-private mutation helpers below.
         key.setArmoredKey(armoredKey);
+        // Keep the MD5 checksum in sync with the stored armored block.
+        // The checksum drifts if we update the block without recomputing it, breaking
+        // any deduplication or integrity checks that rely on this column.
+        key.setMd5(md5Hex(armoredKey));
         key.setMtime(OffsetDateTime.now());
     }
 
-    private boolean hasUid(KeyEntity key, String uidRaw) {
-        // Check the in-memory collection first (avoids extra query when key was just
-        // persisted and the collection is already populated).
-        List<UidEntity> existing = key.getUids();
-        for (UidEntity u : existing) {
-            if (uidRaw.equals(u.getUidRaw())) {
-                return true;
-            }
-        }
-        // Fall back to a database query in case the collection is not yet initialised
-        // (lazy-loaded proxy for a pre-existing key).
+    /// Returns whether a UID row already exists for the given fingerprint and raw UID string.
+    ///
+    /// Uses a single `COUNT` query rather than loading the full UID collection into memory.
+    /// Loading all UIDs to check one can be expensive for keys with many verified UIDs.
+    private boolean hasUid(String fingerprint, String uidRaw) {
         Long count = getEntityManager()
                 .createQuery(
                         "SELECT COUNT(u) FROM UidEntity u WHERE u.key.fingerprint = :fp AND u.uidRaw = :raw",
                         Long.class)
-                .setParameter("fp", key.getFingerprint())
+                .setParameter("fp", fingerprint)
                 .setParameter("raw", uidRaw)
                 .getSingleResult();
         return count > 0;
     }
 
+    /// Returns the raw UID strings of all currently verified UIDs for a key.
+    ///
+    /// Used to compute the "UIDs to keep" set before stripping unverified identities
+    /// from the armored block.  Returns a mutable set so the caller can add the new UID.
+    private Set<String> loadVerifiedUidRaws(String fingerprint) {
+        return getEntityManager()
+                .createQuery(
+                        "SELECT u.uidRaw FROM UidEntity u WHERE u.key.fingerprint = :fp AND u.verified = true",
+                        String.class)
+                .setParameter("fp", fingerprint)
+                .getResultStream()
+                .collect(Collectors.toCollection(java.util.HashSet::new));
+    }
+
+    /// Parses the armored block and returns the master public key of the first ring.
+    ///
+    /// @throws IllegalArgumentException if the input contains no key rings or is malformed.
     private PGPPublicKey parseMasterKey(String armoredKey) {
+        return parseKeyRing(armoredKey).getPublicKey();
+    }
+
+    /// Parses the armored block and returns the first {@link PGPPublicKeyRing}.
+    ///
+    /// @throws IllegalArgumentException if the input contains no key rings or is malformed.
+    private PGPPublicKeyRing parseKeyRing(String armoredKey) {
         try {
             byte[] bytes = armoredKey.getBytes(StandardCharsets.UTF_8);
             try (var stream = PGPUtil.getDecoderStream(new ByteArrayInputStream(bytes))) {
                 PGPPublicKeyRingCollection rings =
                         new PGPPublicKeyRingCollection(stream, new BcKeyFingerprintCalculator());
-                PGPPublicKeyRing ring = rings.iterator().next();
-                return ring.getPublicKey();
+                Iterator<PGPPublicKeyRing> it = rings.iterator();
+                if (!it.hasNext()) {
+                    throw new IllegalArgumentException("Armored input decodes but contains no public key rings");
+                }
+                return it.next();
             }
         } catch (IOException | PGPException e) {
             throw new IllegalArgumentException("Failed to parse armored key: " + e.getMessage(), e);
+        }
+    }
+
+    /// Strips all UIDs except those in `uidRawsToKeep` from the armored key block and
+    /// re-exports the result as ASCII armor.
+    ///
+    /// ## Privacy contract
+    ///
+    /// The raw upload may contain many UIDs (name/email combinations).  We must never
+    /// serve UIDs the owner has not verified via the email flow.  This method removes
+    /// the OpenPGP certification packets for every unverified UID so the stored block
+    /// — and therefore the HKP `op=get` response — only contains verified identities.
+    ///
+    /// ## Note on duplicated BC parsing
+    ///
+    /// `AddKeyToVerificationQueueCommandHandler` also parses armored key blocks using
+    /// Bouncycastle.  The duplication is intentional: the handler lives in the
+    /// application core (infrastructure-free) while this class is the infrastructure
+    /// adapter; sharing code would violate the hexagonal architecture layer boundary.
+    /// A shared `pgp-utils` module could be introduced if the duplication grows.
+    private String stripToVerifiedUids(String armoredKey, Set<String> uidRawsToKeep) {
+        try {
+            PGPPublicKeyRing ring = parseKeyRing(armoredKey);
+            PGPPublicKey masterKey = ring.getPublicKey();
+
+            // Collect UIDs to remove first (avoids ConcurrentModificationException
+            // when mutating certifications while iterating).
+            List<String> uidsToRemove = new ArrayList<>();
+            for (Iterator<String> it = masterKey.getUserIDs(); it.hasNext(); ) {
+                String uid = it.next();
+                if (!uidRawsToKeep.contains(uid)) {
+                    uidsToRemove.add(uid);
+                }
+            }
+
+            // Remove all certification signatures for each unwanted UID.
+            // PGPPublicKey.removeCertification returns a new immutable instance each time.
+            for (String uid : uidsToRemove) {
+                List<PGPSignature> sigsToRemove = new ArrayList<>();
+                for (Iterator<PGPSignature> sigs = masterKey.getSignaturesForID(uid); sigs.hasNext(); ) {
+                    sigsToRemove.add(sigs.next());
+                }
+                for (PGPSignature sig : sigsToRemove) {
+                    masterKey = PGPPublicKey.removeCertification(masterKey, uid, sig);
+                }
+            }
+
+            // Rebuild the ring with the stripped master key and re-export to ASCII armor.
+            ring = PGPPublicKeyRing.insertPublicKey(ring, masterKey);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            try (ArmoredOutputStream armor = new ArmoredOutputStream(out)) {
+                ring.encode(armor);
+            }
+            return out.toString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to strip UIDs from armored key: " + e.getMessage(), e);
         }
     }
 

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.keyserver.repository;
+
+import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
+import io.github.bmarwell.keyserver.repository.entity.KeyEntity;
+import io.github.bmarwell.keyserver.repository.entity.UidEntity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Default;
+import jakarta.transaction.Transactional;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HexFormat;
+import java.util.List;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPPublicKeyRing;
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+import org.bouncycastle.openpgp.PGPUtil;
+import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
+
+/// JPA adapter for the {@link KeyRepository} secondary port.
+///
+/// A key becomes visible in the public key store once at least one of its UIDs has
+/// been email-verified.  Subsequent verifications for the same key append new UID
+/// rows and update the stored armored block (which always reflects only the verified
+/// UIDs as required by the privacy contract in the port Javadoc).
+@Default
+@ApplicationScoped
+public class JpaKeyRepository extends BaseRepository implements KeyRepository {
+
+    @Override
+    @Transactional
+    public void publishVerifiedUid(String fingerprint, String uidRaw, String uidEmail, String armoredKey) {
+        KeyEntity key = getEntityManager().find(KeyEntity.class, fingerprint);
+
+        if (key == null) {
+            key = createKeyEntity(fingerprint, armoredKey);
+            getEntityManager().persist(key);
+        } else {
+            // Update the armored block so it reflects newly verified UIDs (privacy: caller
+            // is responsible for stripping unverified UIDs before passing armoredKey here).
+            updateKey(key, armoredKey);
+        }
+
+        // Add the UID if it is not already present (idempotency guard for retries).
+        if (!hasUid(key, uidRaw)) {
+            UidEntity uid = new UidEntity(key, uidRaw);
+            uid.setUidEmail(uidEmail);
+            uid.setVerified(true);
+            key.addUid(uid);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private KeyEntity createKeyEntity(String fingerprint, String armoredKey) {
+        PGPPublicKey masterKey = parseMasterKey(armoredKey);
+        OffsetDateTime creationTime =
+                Instant.ofEpochMilli(masterKey.getCreationTime().getTime()).atOffset(ZoneOffset.UTC);
+        String md5 = md5Hex(armoredKey);
+        KeyEntity key = new KeyEntity(
+                fingerprint, masterKey.getVersion(), masterKey.getAlgorithm(), creationTime, armoredKey, md5);
+        if (masterKey.getValidSeconds() > 0) {
+            key.setExpirationTime(creationTime.plusSeconds(masterKey.getValidSeconds()));
+        }
+        return key;
+    }
+
+    private void updateKey(KeyEntity key, String armoredKey) {
+        // Use reflection-friendly setter approach: the entity exposes setArmoredKey and
+        // setMtime via package-private mutation helpers below.
+        key.setArmoredKey(armoredKey);
+        key.setMtime(OffsetDateTime.now());
+    }
+
+    private boolean hasUid(KeyEntity key, String uidRaw) {
+        // Check the in-memory collection first (avoids extra query when key was just
+        // persisted and the collection is already populated).
+        List<UidEntity> existing = key.getUids();
+        for (UidEntity u : existing) {
+            if (uidRaw.equals(u.getUidRaw())) {
+                return true;
+            }
+        }
+        // Fall back to a database query in case the collection is not yet initialised
+        // (lazy-loaded proxy for a pre-existing key).
+        Long count = getEntityManager()
+                .createQuery(
+                        "SELECT COUNT(u) FROM UidEntity u WHERE u.key.fingerprint = :fp AND u.uidRaw = :raw",
+                        Long.class)
+                .setParameter("fp", key.getFingerprint())
+                .setParameter("raw", uidRaw)
+                .getSingleResult();
+        return count > 0;
+    }
+
+    private PGPPublicKey parseMasterKey(String armoredKey) {
+        try {
+            byte[] bytes = armoredKey.getBytes(StandardCharsets.UTF_8);
+            try (var stream = PGPUtil.getDecoderStream(new ByteArrayInputStream(bytes))) {
+                PGPPublicKeyRingCollection rings =
+                        new PGPPublicKeyRingCollection(stream, new BcKeyFingerprintCalculator());
+                PGPPublicKeyRing ring = rings.iterator().next();
+                return ring.getPublicKey();
+            }
+        } catch (IOException | PGPException e) {
+            throw new IllegalArgumentException("Failed to parse armored key: " + e.getMessage(), e);
+        }
+    }
+
+    private String md5Hex(String armoredKey) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] digest = md.digest(armoredKey.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            // MD5 is always available in Java.
+            throw new IllegalStateException("MD5 algorithm unavailable", e);
+        }
+    }
+}

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
@@ -63,48 +63,46 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
     @Override
     @Transactional
     public void publishVerifiedUid(String fingerprint, String uidRaw, String uidEmail, String armoredKey) {
-        // Parse the uploaded key block for metadata and an initial single-UID strip.
-        PGPPublicKey masterKey = parseMasterKey(armoredKey);
-        OffsetDateTime creationTime =
-                Instant.ofEpochMilli(masterKey.getCreationTime().getTime()).atOffset(ZoneOffset.UTC);
-        long validSeconds = masterKey.getValidSeconds();
-        Timestamp expTime = validSeconds > 0
-                ? Timestamp.from(creationTime.plusSeconds(validSeconds).toInstant())
-                : null;
-        Integer bitStrength = masterKey.getBitStrength() > 0 ? masterKey.getBitStrength() : null;
-
-        // Strip to just the new UID for the initial row — overwritten unconditionally below,
-        // but needed to satisfy the armored_key NOT NULL constraint on a fresh insert.
-        String initialStripped = stripToVerifiedUids(armoredKey, Set.of(uidRaw));
-        String initialMd5 = md5Hex(initialStripped);
-
-        // Ensure the key row exists before acquiring an exclusive lock.
+        // Fast-path: if the key row already exists we can skip the expensive Bouncy Castle parse
+        // and the native INSERT entirely.  The PESSIMISTIC_WRITE find below will still serialise
+        // concurrent UID publications for the same fingerprint.
         //
-        // ON CONFLICT (fingerprint) DO NOTHING makes this idempotent:
-        //   - If the key does not exist yet, the row is created with the initial strip.
-        //   - If it already exists (or a concurrent transaction just created it),
-        //     PostgreSQL silently skips the insert.
-        //
-        // Concurrent first-publish serialisation: two transactions racing on the same
-        // fingerprint both reach this INSERT.  PostgreSQL serialises them on the PK —
-        // the second blocks until the first commits, then observes the conflict and
-        // continues without inserting.  The PESSIMISTIC_WRITE find below then fully
-        // serialises the armored-key rewrite for both transactions.
-        getEntityManager()
-                .createNativeQuery("INSERT INTO keys"
-                        + " (fingerprint, version, algorithm, bit_strength,"
-                        + "  creation_time, expiration_time, revoked, armored_key, md5)"
-                        + " VALUES (:fp, :ver, :alg, :bs, :ct, :et, false, :ak, :md5)"
-                        + " ON CONFLICT (fingerprint) DO NOTHING")
-                .setParameter("fp", fingerprint)
-                .setParameter("ver", masterKey.getVersion())
-                .setParameter("alg", masterKey.getAlgorithm())
-                .setParameter("bs", bitStrength)
-                .setParameter("ct", Timestamp.from(creationTime.toInstant()))
-                .setParameter("et", expTime)
-                .setParameter("ak", initialStripped)
-                .setParameter("md5", initialMd5)
-                .executeUpdate();
+        // Concurrent first-publish race: two transactions may both see null here and both
+        // attempt the INSERT.  ON CONFLICT (fingerprint) DO NOTHING handles that safely —
+        // the second transaction blocks until the first commits, then silently skips the insert.
+        // The PESSIMISTIC_WRITE find below then serialises both for the armored-key rewrite.
+        if (getEntityManager().find(KeyEntity.class, fingerprint) == null) {
+            // Parse the uploaded key block for metadata — only needed for the initial row.
+            PGPPublicKey masterKey = parseMasterKey(armoredKey);
+            OffsetDateTime creationTime =
+                    Instant.ofEpochMilli(masterKey.getCreationTime().getTime()).atOffset(ZoneOffset.UTC);
+            long validSeconds = masterKey.getValidSeconds();
+            Timestamp expTime = validSeconds > 0
+                    ? Timestamp.from(creationTime.plusSeconds(validSeconds).toInstant())
+                    : null;
+            Integer bitStrength = masterKey.getBitStrength() > 0 ? masterKey.getBitStrength() : null;
+
+            // Strip to just the new UID for the initial row — overwritten unconditionally below,
+            // but needed to satisfy the armored_key NOT NULL constraint on a fresh insert.
+            String initialStripped = stripToVerifiedUids(armoredKey, Set.of(uidRaw));
+            String initialMd5 = md5Hex(initialStripped);
+
+            getEntityManager()
+                    .createNativeQuery("INSERT INTO keys"
+                            + " (fingerprint, version, algorithm, bit_strength,"
+                            + "  creation_time, expiration_time, revoked, armored_key, md5)"
+                            + " VALUES (:fp, :ver, :alg, :bs, :ct, :et, false, :ak, :md5)"
+                            + " ON CONFLICT (fingerprint) DO NOTHING")
+                    .setParameter("fp", fingerprint)
+                    .setParameter("ver", masterKey.getVersion())
+                    .setParameter("alg", masterKey.getAlgorithm())
+                    .setParameter("bs", bitStrength)
+                    .setParameter("ct", Timestamp.from(creationTime.toInstant()))
+                    .setParameter("et", expTime)
+                    .setParameter("ak", initialStripped)
+                    .setParameter("md5", initialMd5)
+                    .executeUpdate();
+        }
 
         // Acquire an exclusive row lock — serialises concurrent UID publications for
         // the same key from this point forward.  The row is guaranteed to exist after

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
@@ -21,6 +21,7 @@ import io.github.bmarwell.keyserver.repository.entity.KeyEntity;
 import io.github.bmarwell.keyserver.repository.entity.UidEntity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
+import jakarta.persistence.LockModeType;
 import jakarta.transaction.Transactional;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -28,6 +29,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -61,25 +63,62 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
     @Override
     @Transactional
     public void publishVerifiedUid(String fingerprint, String uidRaw, String uidEmail, String armoredKey) {
-        KeyEntity key = getEntityManager().find(KeyEntity.class, fingerprint);
+        // Parse the uploaded key block for metadata and an initial single-UID strip.
+        PGPPublicKey masterKey = parseMasterKey(armoredKey);
+        OffsetDateTime creationTime =
+                Instant.ofEpochMilli(masterKey.getCreationTime().getTime()).atOffset(ZoneOffset.UTC);
+        long validSeconds = masterKey.getValidSeconds();
+        Timestamp expTime = validSeconds > 0
+                ? Timestamp.from(creationTime.plusSeconds(validSeconds).toInstant())
+                : null;
+        Integer bitStrength = masterKey.getBitStrength() > 0 ? masterKey.getBitStrength() : null;
 
-        if (key == null) {
-            // Privacy: strip all UIDs except the one being verified now.
-            // The queued armoredKey is the raw user upload containing ALL UIDs.
-            // We must not publish unverified identities — only serve what the owner
-            // has actively confirmed via the email link.
-            String stripped = stripToVerifiedUids(armoredKey, Set.of(uidRaw));
-            key = createKeyEntity(fingerprint, stripped);
-            getEntityManager().persist(key);
-        } else {
-            // Build the set of already-verified UIDs plus the new one being confirmed.
-            // Re-strip from the original armored key (which was stored in the queue) so
-            // the stored block always reflects exactly the verified-UID set and nothing more.
-            Set<String> verifiedUids = loadVerifiedUidRaws(fingerprint);
-            verifiedUids.add(uidRaw);
-            String stripped = stripToVerifiedUids(armoredKey, verifiedUids);
-            updateKey(key, stripped);
-        }
+        // Strip to just the new UID for the initial row — overwritten unconditionally below,
+        // but needed to satisfy the armored_key NOT NULL constraint on a fresh insert.
+        String initialStripped = stripToVerifiedUids(armoredKey, Set.of(uidRaw));
+        String initialMd5 = md5Hex(initialStripped);
+
+        // Ensure the key row exists before acquiring an exclusive lock.
+        //
+        // ON CONFLICT (fingerprint) DO NOTHING makes this idempotent:
+        //   - If the key does not exist yet, the row is created with the initial strip.
+        //   - If it already exists (or a concurrent transaction just created it),
+        //     PostgreSQL silently skips the insert.
+        //
+        // Concurrent first-publish serialisation: two transactions racing on the same
+        // fingerprint both reach this INSERT.  PostgreSQL serialises them on the PK —
+        // the second blocks until the first commits, then observes the conflict and
+        // continues without inserting.  The PESSIMISTIC_WRITE find below then fully
+        // serialises the armored-key rewrite for both transactions.
+        getEntityManager()
+                .createNativeQuery("INSERT INTO keys"
+                        + " (fingerprint, version, algorithm, bit_strength,"
+                        + "  creation_time, expiration_time, revoked, armored_key, md5)"
+                        + " VALUES (:fp, :ver, :alg, :bs, :ct, :et, false, :ak, :md5)"
+                        + " ON CONFLICT (fingerprint) DO NOTHING")
+                .setParameter("fp", fingerprint)
+                .setParameter("ver", masterKey.getVersion())
+                .setParameter("alg", masterKey.getAlgorithm())
+                .setParameter("bs", bitStrength)
+                .setParameter("ct", Timestamp.from(creationTime.toInstant()))
+                .setParameter("et", expTime)
+                .setParameter("ak", initialStripped)
+                .setParameter("md5", initialMd5)
+                .executeUpdate();
+
+        // Acquire an exclusive row lock — serialises concurrent UID publications for
+        // the same key from this point forward.  The row is guaranteed to exist after
+        // the INSERT above, so PESSIMISTIC_WRITE will always find a row to lock.
+        KeyEntity key = getEntityManager().find(KeyEntity.class, fingerprint, LockModeType.PESSIMISTIC_WRITE);
+
+        // Reload the set of already-committed verified UIDs (from prior transactions),
+        // add the new UID, and re-strip the original upload block.  This guarantees
+        // the stored armored block always contains exactly the verified-UID set —
+        // no more, no less — regardless of which transaction ran first.
+        Set<String> verifiedUids = loadVerifiedUidRaws(fingerprint);
+        verifiedUids.add(uidRaw);
+        String stripped = stripToVerifiedUids(armoredKey, verifiedUids);
+        updateKey(key, stripped);
 
         // Add the UID row if not already present (idempotency guard for retries).
         if (!hasUid(key.getFingerprint(), uidRaw)) {
@@ -103,9 +142,13 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
 
         String normalized = search.strip();
 
-        // Fingerprint or key-ID search: starts with 0x or is all-hex
-        if (normalized.startsWith("0x") || isHexString(normalized)) {
-            return findByKeyIdOrFingerprint(normalized.startsWith("0x") ? normalized.substring(2) : normalized);
+        // Key-ID/fingerprint: starts with 0x or is all-hex with a valid key-ID/fingerprint length.
+        // Only take this path for lengths 8 (short key ID), 16 (long key ID), 40 (v4 fingerprint),
+        // or 64 (v5 fingerprint).  All-hex strings of other lengths (e.g. "cafe", a colour name
+        // that happens to be hex) must fall through to UID-substring search.
+        String hexCandidate = normalized.startsWith("0x") ? normalized.substring(2) : normalized;
+        if ((normalized.startsWith("0x") || isHexString(hexCandidate)) && isValidKeyIdLength(hexCandidate.length())) {
+            return findByKeyIdOrFingerprint(hexCandidate);
         }
 
         // Email search
@@ -121,21 +164,34 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
     }
 
     private Optional<KeySearchResult> findByKeyIdOrFingerprint(String hexValue) {
-        String lower = hexValue.toLowerCase(Locale.ROOT);
-        int len = lower.length();
+        // Normalise to uppercase: fingerprint (and the DB-generated keyid_long column) are stored
+        // as uppercase.  Avoiding LOWER() on the column allows the DB to use the keys_keyid_long
+        // index and the keys_rfingerprint text_pattern_ops index.
+        String upper = hexValue.toUpperCase(Locale.ROOT);
+        int len = upper.length();
+
         if (len == 40 || len == 64) {
-            // Full fingerprint — try uppercase first (as stored by the handler)
-            KeyEntity key = getEntityManager().find(KeyEntity.class, lower.toUpperCase(Locale.ROOT));
-            if (key == null) {
-                key = getEntityManager().find(KeyEntity.class, lower);
-            }
-            return toResult(key);
+            // Full fingerprint — primary key lookup (always indexed).
+            return toResult(getEntityManager().find(KeyEntity.class, upper));
         }
-        // Short (8) or long (16) key ID — match via keyid_long suffix
-        String suffix = len == 8 ? "%" + lower : lower;
+
+        if (len == 16) {
+            // Long key ID: exact match on the generated keyid_long column (uses keys_keyid_long index).
+            List<KeyEntity> results = getEntityManager()
+                    .createQuery("SELECT k FROM KeyEntity k WHERE k.keyidLong = :keyId", KeyEntity.class)
+                    .setParameter("keyId", upper)
+                    .setMaxResults(1)
+                    .getResultList();
+            return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
+        }
+
+        // Short key ID (8 chars): reverse it and use the rfingerprint text_pattern_ops index for a
+        // prefix scan.  reverse(fingerprint) starts with reverse(shortKeyId), so this matches the
+        // last 8 chars of the fingerprint without a leading-wildcard LIKE on the forward column.
+        String reversedShortId = new StringBuilder(upper).reverse().toString();
         List<KeyEntity> results = getEntityManager()
-                .createQuery("SELECT k FROM KeyEntity k WHERE LOWER(k.keyidLong) LIKE :suffix", KeyEntity.class)
-                .setParameter("suffix", suffix)
+                .createQuery("SELECT k FROM KeyEntity k WHERE k.rfingerprint LIKE :prefix", KeyEntity.class)
+                .setParameter("prefix", reversedShortId + "%")
                 .setMaxResults(1)
                 .getResultList();
         return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
@@ -188,22 +244,14 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
         return true;
     }
 
+    private static boolean isValidKeyIdLength(int len) {
+        // 8 = short key ID, 16 = long key ID, 40 = v4 fingerprint, 64 = v5 fingerprint.
+        return len == 8 || len == 16 || len == 40 || len == 64;
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
-
-    private KeyEntity createKeyEntity(String fingerprint, String armoredKey) {
-        PGPPublicKey masterKey = parseMasterKey(armoredKey);
-        OffsetDateTime creationTime =
-                Instant.ofEpochMilli(masterKey.getCreationTime().getTime()).atOffset(ZoneOffset.UTC);
-        String md5 = md5Hex(armoredKey);
-        KeyEntity key = new KeyEntity(
-                fingerprint, masterKey.getVersion(), masterKey.getAlgorithm(), creationTime, armoredKey, md5);
-        if (masterKey.getValidSeconds() > 0) {
-            key.setExpirationTime(creationTime.plusSeconds(masterKey.getValidSeconds()));
-        }
-        return key;
-    }
 
     private void updateKey(KeyEntity key, String armoredKey) {
         key.setArmoredKey(armoredKey);

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaVerificationQueueRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaVerificationQueueRepository.java
@@ -24,6 +24,7 @@ import io.hypersistence.tsid.TSID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Inject;
+import jakarta.persistence.LockModeType;
 import jakarta.transaction.Transactional;
 import java.util.Optional;
 
@@ -57,7 +58,13 @@ public class JpaVerificationQueueRepository extends BaseRepository implements Ve
     @Override
     @Transactional
     public Optional<VerificationEntry> findPendingById(long tokenId) {
-        VerificationQueueEntity entity = getEntityManager().find(VerificationQueueEntity.class, tokenId);
+        // PESSIMISTIC_WRITE prevents two concurrent transactions from both reading
+        // PENDING and then both proceeding to publish the same UID (TOCTOU race).
+        // The second transaction will block here until the first commits, at which
+        // point the state is VERIFIED and this method returns empty — effectively
+        // making token consumption a one-time operation under concurrent load.
+        VerificationQueueEntity entity =
+                getEntityManager().find(VerificationQueueEntity.class, tokenId, LockModeType.PESSIMISTIC_WRITE);
         if (entity == null || entity.getState() != VerificationQueueState.PENDING) {
             return Optional.empty();
         }

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaVerificationQueueRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaVerificationQueueRepository.java
@@ -16,13 +16,16 @@
 package io.github.bmarwell.keyserver.repository;
 
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
+import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationEntry;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationRequest;
 import io.github.bmarwell.keyserver.repository.entity.VerificationQueueEntity;
+import io.github.bmarwell.keyserver.repository.entity.VerificationQueueState;
 import io.hypersistence.tsid.TSID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import java.util.Optional;
 
 /// JPA adapter for the {@link VerificationQueueRepository} secondary port.
 ///
@@ -49,6 +52,31 @@ public class JpaVerificationQueueRepository extends BaseRepository implements Ve
                 request.expiresAt());
         getEntityManager().persist(entity);
         return id;
+    }
+
+    @Override
+    @Transactional
+    public Optional<VerificationEntry> findPendingById(long tokenId) {
+        VerificationQueueEntity entity = getEntityManager().find(VerificationQueueEntity.class, tokenId);
+        if (entity == null || entity.getState() != VerificationQueueState.PENDING) {
+            return Optional.empty();
+        }
+        return Optional.of(new VerificationEntry(
+                entity.getId(),
+                entity.getFingerprint(),
+                entity.getUidRaw(),
+                entity.getUidEmail(),
+                entity.getArmoredKey(),
+                entity.getExpiresAt()));
+    }
+
+    @Override
+    @Transactional
+    public void markVerified(long tokenId) {
+        VerificationQueueEntity entity = getEntityManager().find(VerificationQueueEntity.class, tokenId);
+        if (entity != null) {
+            entity.setState(VerificationQueueState.VERIFIED);
+        }
     }
 
     public void setTsidFactory(TSID.Factory tsidFactory) {

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/KeyEntity.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/KeyEntity.java
@@ -157,6 +157,14 @@ public class KeyEntity {
         return armoredKey;
     }
 
+    public void setArmoredKey(String armoredKey) {
+        this.armoredKey = armoredKey;
+    }
+
+    public void setMtime(OffsetDateTime mtime) {
+        this.mtime = mtime;
+    }
+
     public String getMd5() {
         return md5;
     }

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/KeyEntity.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/KeyEntity.java
@@ -169,6 +169,10 @@ public class KeyEntity {
         return md5;
     }
 
+    public void setMd5(String md5) {
+        this.md5 = md5;
+    }
+
     public OffsetDateTime getCtime() {
         return ctime;
     }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/LookupEndpoint.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/LookupEndpoint.java
@@ -16,7 +16,6 @@
 package io.github.bmarwell.keyserver.web.pks;
 
 import io.github.bmarwell.keyserver.application.api.KeyRepositoryService;
-import io.github.bmarwell.keyserver.application.api.ex.KeyNotFoundException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -43,7 +42,8 @@ public class LookupEndpoint {
     public Response doLookup(
             @QueryParam("op") String op, @QueryParam("search") String search, @QueryParam("exact") String exact) {
 
-        if (op == null || search == null || search.isBlank()) {
+        // Both null and blank op are invalid — HKP requires a non-empty op parameter.
+        if (op == null || op.isBlank() || search == null || search.isBlank()) {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity("Missing required parameters: op and search")
                     .type("text/plain")
@@ -66,7 +66,13 @@ public class LookupEndpoint {
     private Response handleGet(String search, boolean exactMatch) {
         Optional<String> armoredKey = keyRepositoryService.getArmoredKeyBySearch(search, exactMatch);
         if (armoredKey.isEmpty()) {
-            throw new KeyNotFoundException("No key found for: " + search);
+            // Return plain text 404 for consistency with other HKP error responses.
+            // Throwing KeyNotFoundException would invoke the JSON exception mapper,
+            // which mixes content types and confuses HKP clients expecting text/plain.
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("No key found for the provided search term")
+                    .type("text/plain")
+                    .build();
         }
         return Response.ok(armoredKey.get())
                 .type("application/pgp-keys; charset=us-ascii")

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/LookupEndpoint.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/LookupEndpoint.java
@@ -16,20 +16,22 @@
 package io.github.bmarwell.keyserver.web.pks;
 
 import io.github.bmarwell.keyserver.application.api.KeyRepositoryService;
-import io.github.bmarwell.keyserver.common.ids.KeyId;
-import io.github.bmarwell.keyserver.common.ids.PgpPublicKey;
+import io.github.bmarwell.keyserver.application.api.ex.KeyNotFoundException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.Optional;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-/**
- * Implementation of the OpenPGP Keyserver protocol.
- */
+/// HKP `/pks/lookup` endpoint.
+///
+/// Handles `op=get` (return ASCII-armored key block) and stubs `op=index`/`op=vindex`
+/// (machine-readable listing — future work).
+///
+/// Only keys with at least one verified UID are returned.  Search by fingerprint
+/// (`0x<hex>`), long/short key ID, email address, or UID substring.
 @Tag(name = "OpenPGP Keyserver Protocol: Lookup")
 @Path("lookup")
 public class LookupEndpoint {
@@ -38,35 +40,41 @@ public class LookupEndpoint {
     KeyRepositoryService keyRepositoryService;
 
     @GET
-    public Response doLookup(@QueryParam("op") String op, @QueryParam("search") String search) {
-        if (op.equals("get") && !search.isBlank()) {
-            /*
-             * The response to a successful "get" request is a HTTP document containing a keyring
-             * as specified in OpenPGP [RFC4880], section 11.1,
-             * and ASCII armored as specified in section 6.2.
-             */
-            Optional<PgpPublicKey> foundKey = this.keyRepositoryService.getKeyByKeyId(KeyId.fromString(search));
-            if (foundKey.isEmpty()) {
-                return Response.status(Response.Status.NOT_FOUND)
-                        .encoding(MediaType.TEXT_PLAIN)
-                        .entity("Not Found")
-                        .build();
-            }
+    public Response doLookup(
+            @QueryParam("op") String op, @QueryParam("search") String search, @QueryParam("exact") String exact) {
 
-            // TODO: return armored-keys
-            return Response.status(Response.Status.OK)
-                    .encoding("application/pgp-keys; charset=us-ascii")
+        if (op == null || search == null || search.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("Missing required parameters: op and search")
+                    .type("text/plain")
                     .build();
         }
 
-        return Response.status(Response.Status.NOT_IMPLEMENTED).build();
+        boolean exactMatch = "on".equalsIgnoreCase(exact);
+
+        if ("get".equalsIgnoreCase(op)) {
+            return handleGet(search, exactMatch);
+        }
+
+        // op=index and op=vindex are future work
+        return Response.status(Response.Status.NOT_IMPLEMENTED)
+                .entity("op=" + op + " is not yet implemented")
+                .type("text/plain")
+                .build();
     }
 
-    public KeyRepositoryService getRepositoryService() {
-        return keyRepositoryService;
+    private Response handleGet(String search, boolean exactMatch) {
+        Optional<String> armoredKey = keyRepositoryService.getArmoredKeyBySearch(search, exactMatch);
+        if (armoredKey.isEmpty()) {
+            throw new KeyNotFoundException("No key found for: " + search);
+        }
+        return Response.ok(armoredKey.get())
+                .type("application/pgp-keys; charset=us-ascii")
+                .build();
     }
 
-    public void setRepositoryService(KeyRepositoryService keyRepositoryService) {
+    // CDI-friendly setter for unit testing
+    public void setKeyRepositoryService(KeyRepositoryService keyRepositoryService) {
         this.keyRepositoryService = keyRepositoryService;
     }
 }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/LookupEndpoint.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/LookupEndpoint.java
@@ -42,10 +42,14 @@ public class LookupEndpoint {
     public Response doLookup(
             @QueryParam("op") String op, @QueryParam("search") String search, @QueryParam("exact") String exact) {
 
-        // Both null and blank op are invalid — HKP requires a non-empty op parameter.
-        if (op == null || op.isBlank() || search == null || search.isBlank()) {
+        // Both null/blank op and search are invalid — HKP requires both to be present.
+        // Report exactly which parameter(s) are missing so the client can self-correct.
+        boolean missingOp = op == null || op.isBlank();
+        boolean missingSearch = search == null || search.isBlank();
+        if (missingOp || missingSearch) {
+            String missing = missingOp && missingSearch ? "op and search" : missingOp ? "op" : "search";
             return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("Missing required parameters: op and search")
+                    .entity("Missing required parameter(s): " + missing)
                     .type("text/plain")
                     .build();
         }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyEndpoint.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyEndpoint.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import io.github.bmarwell.keyserver.application.api.CommandService;
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
+import io.github.bmarwell.keyserver.application.api.commands.VerifyUidCommand;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+/// Handles the email-verification link clicked by a key owner.
+///
+/// ## Async dispatch
+///
+/// The command is dispatched via the standard async `CommandService`.  This means
+/// the response is `202 Accepted` and the caller does not receive inline success or
+/// failure feedback.  A future iteration should add a synchronous invocation path
+/// (or polling mechanism) so the user sees a meaningful confirmation page.
+///
+/// ## Caller context
+///
+/// The IP is not forwarded for the verification step: the token already serves as
+/// a one-time credential and IP attribution here adds no audit value.
+/// {@link CommandCallerContext#empty()} is used.
+@Tag(name = "OpenPGP Keyserver Protocol: Verify")
+@Path("verify")
+public class VerifyEndpoint {
+
+    @Inject
+    CommandService commandService;
+
+    /// Consumes a verification token from a link sent to the key owner's email
+    /// address and schedules the corresponding UID for publication.
+    ///
+    /// @param token the TSID of the verification-queue entry, as an unsigned decimal string
+    /// @return `202 Accepted` — the verification is processed asynchronously
+    @GET
+    @Path("{token}")
+    @Operation(summary = "Confirm email ownership via verification link")
+    public Response verify(@PathParam("token") String token) {
+        var command = new VerifyUidCommand(token);
+        commandService.handleCommand(command, CommandCallerContext.empty());
+        return Response.accepted().build();
+    }
+
+    public void setCommandService(CommandService commandService) {
+        this.commandService = commandService;
+    }
+}


### PR DESCRIPTION
## Summary

Implements the complete key submission and verification flow plus HKP lookup.

### Commits

1. **feat: VerifyUidCommand — email verification flow + DoS guard**
   - `VerifyUidCommand` record + `VerifyUidCommandHandler`
   - `VerifyEndpoint` (GET /verify/{token}) — async 202
   - `TooManyVerifiableUidsException` sealed under `KeyValidationException`
   - Unit tests covering all 6 scenarios (no email, timeout, single click, partial click, both clicked, DoS guard)
   - MAX_EMAIL_UIDS = 20 (SKS poisoning guard; keys.openpgp.org caps at 5)

2. **feat: JpaKeyRepository — publishVerifiedUid JPA adapter**
   - New `JpaKeyRepository` implementing the `KeyRepository` secondary port
   - Creates/updates `KeyEntity` from BouncyCastle-parsed armored key
   - Adds `UidEntity` idempotently
   - BouncyCastle (bcpg + bcprov) added to repository module

3. **feat: LookupEndpoint — HKP op=get via KeyRepository.findBySearch**
   - `KeyRepository` extended with `KeySearchResult` record + `findBySearch()`
   - `JpaKeyRepository.findBySearch()`: dispatches on fingerprint (40/64 hex), keyid (8/16 hex), email, UID substring
   - `LookupEndpoint` rewritten: op=get → armored key; op=index → 501; missing params → 400; not found → 404

### Notes
- Full verification token is logged intentionally (test mode); tracked in `docs/implementation-plan.adoc`
- Integration tests (Liberty + PostgreSQL via Testcontainers) are planned, not yet implemented