### PR TITLE
docs: update architecture and plan after verify-uid merge

### DIFF
--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -56,7 +56,7 @@ adapters implement them.
 
 |`KeyRepository`
 |`application-port-repository`
-|_(stub)_
+|`JpaKeyRepository` in `repository`
 
 |`VerificationNotificationPort`
 |`application-port-notification`
@@ -74,9 +74,13 @@ adapters implement them.
 |`web/openpgp-keyserver-protocol`
 |`CommandService`
 
-|`LookupEndpoint` _(stub)_
+|`LookupEndpoint` (`op=get` implemented; `op=index`/`op=vindex` return 501)
 |`web/openpgp-keyserver-protocol`
-|`KeyRepository`
+|`KeyRepositoryService`
+
+|`VerifyEndpoint`
+|`web/openpgp-keyserver-protocol`
+|`CommandService`
 
 |===
 
@@ -146,11 +150,29 @@ For lookup use cases, the flow is shorter:
 
 == 6. Weak spots
 
-* Many end-to-end flows are still stubs or return `501/503`.
+* `op=index` and `op=vindex` are not implemented (`LookupEndpoint` returns 501).
+  GnuPG key search via name/email therefore fails — only fingerprint/key-ID
+  `op=get` works. HKP compliance is partial.
+* `VerifyEndpoint` always returns `202 Accepted` regardless of outcome.
+  The caller never sees success or failure; there is no polling endpoint.
+* Async command dispatch is opaque to the HTTP caller: exceptions in the virtual-thread
+  executor are logged but not surfaced. A future iteration needs at minimum a
+  correlation-ID header so errors can be traced.
+* The `business_transactions.fingerprint` column is always null — no handler
+  populates it yet.
+* `web/rest` endpoints return `503 Service Unavailable` on every call.
+  The module compiles and deploys but provides no usable functionality.
+* `SmtpVerificationNotificationAdapter` is not wired. Only the logging adapter
+  exists, so no actual verification email is sent.
+* No HTTP-layer rate limiting on `POST /pks/add`. The DoS guard in
+  `VerifyUidCommandHandler` defends the verification queue but the add path
+  is unguarded.
 * Command dispatch is runtime-based (`canHandle`) rather than compile-time safe.
-* Validation, persistence, and response rendering are incomplete.
-* The current tests mostly cover dispatch behavior, not the protocol flows.
-* Some helper and adapter types are only partially implemented.
+  An unregistered command type silently fails at runtime with a warning log.
+* `publishVerifiedUid` has a minor TOCTOU: two concurrent first-publish transactions
+  both pass the non-locking existence check, both do a full Bouncy Castle parse.
+  The `ON CONFLICT DO NOTHING` INSERT serialises correctly, but one of the two
+  parses is wasted.  Acceptable in practice; worth noting for honesty.
 
 == 7. Where the design fits well
 
@@ -159,6 +181,57 @@ For lookup use cases, the flow is shorter:
 * Value objects reduce stringly-typed plumbing.
 * The ports/adapters boundary should make future storage or mail replacements easy.
 * Flyway plus JPA is a sensible fit for repository metadata and queue state.
+* The full UID-verification flow (scenarios 1–7) is implemented end-to-end:
+  submission, token dispatch, expiry guard, concurrent same-fingerprint and
+  same-UID race conditions, and armored-key rewriting with exactly the verified
+  UID set.  All seven scenarios have unit tests.
+* Concurrent UID publication is correctly serialised via
+  `INSERT … ON CONFLICT (fingerprint) DO NOTHING` followed by a
+  `PESSIMISTIC_WRITE` row lock — no application-level locking needed.
+* Third-party certification stripping is in place: only self-signatures are
+  stored, preventing the server from becoming a social-graph database.
+
+== 9. Verification flow
+
+=== Happy path
+
+[source]
+----
+POST /pks/add?keytext=…
+  → AddKeyToVerificationQueueCommandHandler
+    → JpaVerificationQueueRepository: insert one queue row per UID
+    → VerificationNotificationPort: send email with /pks/verify/{token} link
+
+GET /pks/verify/{token}
+  → VerifyUidCommandHandler
+    → JpaVerificationQueueRepository: find pending row by token
+      [guard] token not found         → TokenInvalidException  (400)
+      [guard] token expired           → TokenExpiredException  (400)
+      [guard] already verified        → return (idempotent, no re-send)
+    → JpaKeyRepository.publishVerifiedUid(fingerprint, uidRaw, uidEmail, armoredKey)
+      → existence check (non-locking find)
+      → if new: parseMasterKey + strip to one UID + INSERT ON CONFLICT DO NOTHING
+      → PESSIMISTIC_WRITE find (serialises concurrent updates)
+      → reload all verified UIDs + re-strip armored block + updateKey
+      → hasUid guard → add UidEntity if absent
+    → JpaVerificationQueueRepository: mark row VERIFIED
+----
+
+=== Concurrent first-publish (scenario 7)
+
+Two `VerifyUidCommand` calls for different UIDs on the same fingerprint race
+at exactly the same moment:
+
+. Both pass the non-locking existence check (`find == null`).
+. Both parse the armored key (one parse is wasted — acceptable overhead).
+. Both attempt the native INSERT. PostgreSQL serialises on the fingerprint PK:
+   the second blocks until the first commits, then observes the conflict and
+   skips the insert.
+. Both then do a `PESSIMISTIC_WRITE` find, which serialises sequentially.
+. Each transaction reloads the current verified-UID set, adds its own UID,
+   and re-strips.  The final committed state contains both UIDs.
+
+No UID is lost and no dirty state is written.
 
 == 8. Identity strategy
 
@@ -317,5 +390,13 @@ Its weak points that we address differently:
 
 == 12. Current state
 
-This repository has a promising structure but is not yet functionally complete.
-Treat this document as an orientation guide, not a stable architecture promise.
+The add → verify → lookup path for `op=get` is functionally complete:
+a key can be submitted, its UIDs verified by email link, and retrieved
+by fingerprint, key ID, or email.
+
+Remaining gaps: `op=index`/`op=vindex` not implemented, SMTP not wired,
+`web/rest` stubs only, no HTTP rate limiting on add.  The architecture is
+sound; the functional surface is narrow.
+
+This document is kept deliberately short.  Section numbers reflect deliberate
+ordering; section 9 was added to fill the gap that existed between §8 and §10.

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -153,13 +153,16 @@ For lookup use cases, the flow is shorter:
 * `op=index` and `op=vindex` are not implemented (`LookupEndpoint` returns 501).
   GnuPG key search via name/email therefore fails — only fingerprint/key-ID
   `op=get` works. HKP compliance is partial.
+* The HKP `KeyServerExceptionMapper` incorrectly returns `application/json`.
+  HKP clients (GnuPG, gpg2) expect `text/plain` for error responses.  The REST
+  mapper is correct; the HKP mapper must be fixed separately (#132).
 * `VerifyEndpoint` always returns `202 Accepted` regardless of outcome.
-  The caller never sees success or failure; there is no polling endpoint.
+  The caller never sees success or failure; there is no polling endpoint (#140).
 * Async command dispatch is opaque to the HTTP caller: exceptions in the virtual-thread
-  executor are logged but not surfaced. A future iteration needs at minimum a
+  executor are logged but not surfaced.  A future iteration needs at minimum a
   correlation-ID header so errors can be traced.
 * The `business_transactions.fingerprint` column is always null — no handler
-  populates it yet.
+  populates it yet (#139).
 * `web/rest` endpoints return `503 Service Unavailable` on every call.
   The module compiles and deploys but provides no usable functionality.
 * `SmtpVerificationNotificationAdapter` is not wired. Only the logging adapter
@@ -167,12 +170,20 @@ For lookup use cases, the flow is shorter:
 * No HTTP-layer rate limiting on `POST /pks/add`. The DoS guard in
   `VerifyUidCommandHandler` defends the verification queue but the add path
   is unguarded.
+* **DoS on add**: subkey count is not capped (#136). A key with tens of thousands
+  of subkeys is fully parsed by Bouncy Castle and later triggers one
+  `stripToVerifiedUids` call per verified UID.  `keytext` size is also uncapped
+  (#135).
+* **BTX left open**: if `recordCompleted()` itself throws after a successful
+  handler, the BTX row stays in `STARTED` state forever (#134).
 * Command dispatch is runtime-based (`canHandle`) rather than compile-time safe.
   An unregistered command type silently fails at runtime with a warning log.
 * `publishVerifiedUid` has a minor TOCTOU: two concurrent first-publish transactions
   both pass the non-locking existence check, both do a full Bouncy Castle parse.
   The `ON CONFLICT DO NOTHING` INSERT serialises correctly, but one of the two
   parses is wasted.  Acceptable in practice; worth noting for honesty.
+* No VKS-compatible API (`/vks/v1/…`) yet.  Implementing the keys.openpgp.org
+  surface would allow integration tests to reuse the Hagrid test suite (#138).
 
 == 7. Where the design fits well
 

--- a/docs/implementation-plan.adoc
+++ b/docs/implementation-plan.adoc
@@ -692,8 +692,10 @@ See also `.github/AGENTS.adoc § Privacy rules`.
   serialisation point, avoiding application-level locking.
 * Indexed short key-ID search uses `rfingerprint` with `text_pattern_ops` —
   `LOWER()` on the column was correctly removed after being introduced initially.
-* Verification token values are never logged, even in exception messages —
-  discovered and fixed during review.
+* Verification token values are not logged in exception messages or domain-error
+  paths — discovered and fixed during review. The current first-iteration
+  `LoggingVerificationNotificationAdapter` remains an explicit, temporary logging
+  exception as documented above.
 
 === 9.2 Honest design debts introduced during implementation
 

--- a/docs/implementation-plan.adoc
+++ b/docs/implementation-plan.adoc
@@ -682,9 +682,9 @@ is wired.  Either:
 The `TODO` comment in `LoggingVerificationNotificationAdapter` marks the location.
 See also `.github/AGENTS.adoc § Privacy rules`.
 
-== 9. Self-critique and known design debts
+== 10. Self-critique and known design debts
 
-=== 9.1 Things that were done well
+=== 10.1 Things that were done well
 
 * The port/adapter split held cleanly through the VerifyUID work — no leakage
   of JPA types into the core or HTTP types into the repository.
@@ -697,7 +697,7 @@ See also `.github/AGENTS.adoc § Privacy rules`.
   `LoggingVerificationNotificationAdapter` remains an explicit, temporary logging
   exception as documented above.
 
-=== 9.2 Honest design debts introduced during implementation
+=== 10.2 Honest design debts introduced during implementation
 
 ==== TOCTOU in `publishVerifiedUid`
 

--- a/docs/implementation-plan.adoc
+++ b/docs/implementation-plan.adoc
@@ -453,24 +453,27 @@ try {
 
 * ✅ `BusinessTransactionRepository` — BTX lifecycle port (replaces the former `AuditLogPort` idea).
 * ✅ `VerificationQueueRepository` — replaces the former `KeyVerificationQueueDao`.
-* Add `KeyRepository` (replaces stub) with methods for fingerprint/key-ID lookup and insert.
+* ✅ Add `KeyRepository` (replaces stub) with methods for fingerprint/key-ID lookup and insert.
 * Add `UidRepository` for UID-level reads needed by `op=index`.
 
 === 6.5 `repository`
 
 * ✅ `BusinessTransactionEntity` + `PersistentBusinessTransactionRepository`.
 * ✅ `VerificationQueueEntity` + `JpaVerificationQueueRepository`.
-* Add JPA entities: `KeyEntity`, `UidEntity`.
-* Add Flyway migrations for the new tables (see §2).
+* ✅ JPA entities: `KeyEntity`, `UidEntity`.
+* ✅ Flyway migrations for keys and uids tables.
+* Add `UidRepository` for UID-level reads needed by `op=index`.
 
 === 6.6 `web/openpgp-keyserver-protocol`
 
 * ✅ `AddEndpoint`: `application/x-www-form-urlencoded`, `keytext` form parameter,
   IP anonymization via `IpAnonymizer`.
+* ✅ `LookupEndpoint`: `op=get` implemented; fingerprint, long/short key-ID,
+  email search via `JpaKeyRepository.findBySearch`.  `op=index`/`op=vindex` return 501.
+* ✅ `VerifyEndpoint`: consumes verification token, dispatches `VerifyUidCommand`.
+* ✅ `KeyServerExceptionMapper` for `KeyServerException` subtypes.
 * `LookupEndpoint`: implement `op=index` and `op=vindex` with machine-readable
   output.  Honor `options=mr` and `exact=on`.
-* Add `KeyServerExceptionMapper` implementing `ExceptionMapper<KeyServerException>`.
-* Add `InvalidKeyIdExceptionMapper` for the `common/ids` parsing error.
 
 === 6.7 `web/rest`
 
@@ -678,3 +681,51 @@ is wired.  Either:
 
 The `TODO` comment in `LoggingVerificationNotificationAdapter` marks the location.
 See also `.github/AGENTS.adoc § Privacy rules`.
+
+== 9. Self-critique and known design debts
+
+=== 9.1 Things that were done well
+
+* The port/adapter split held cleanly through the VerifyUID work — no leakage
+  of JPA types into the core or HTTP types into the repository.
+* Concurrent first-publish (scenario 7) is solved with a single `INSERT … ON CONFLICT`
+  serialisation point, avoiding application-level locking.
+* Indexed short key-ID search uses `rfingerprint` with `text_pattern_ops` —
+  `LOWER()` on the column was correctly removed after being introduced initially.
+* Verification token values are never logged, even in exception messages —
+  discovered and fixed during review.
+
+=== 9.2 Honest design debts introduced during implementation
+
+==== TOCTOU in `publishVerifiedUid`
+
+The "skip BC parse if key exists" optimisation uses a non-locking `find` before
+the INSERT.  Two concurrent first-publish transactions can both pass that check,
+both do a full Bouncy Castle parse, and one of the two parses is discarded.
+The `ON CONFLICT DO NOTHING` INSERT still serialises correctly; this is a wasted
+CPU cycle, not a correctness bug.
+
+==== `Assertions.fail()` instead of AssertJ in scenario 7 test
+
+`VerifyUidCommandHandlerTest` uses `org.junit.jupiter.api.Assertions.fail()` in
+the timeout branch while the rest of the file uses AssertJ.  Should be replaced
+with `assertThat(completed).as("threads completed within timeout").isTrue()`.
+
+==== `VerifyEndpoint` always returns 202
+
+The verification endpoint cannot distinguish success from failure in its current
+form — the command is dispatched asynchronously and the HTTP thread returns before
+the outcome is known.  The user receives no feedback.  A synchronous verification
+path (or a status-polling endpoint) is needed for a production-grade UX.
+
+==== `business_transactions.fingerprint` always null
+
+No handler populates the fingerprint column on the BTX row.
+Operators cannot filter the audit log by key fingerprint.
+
+==== Error response content type
+
+`LookupEndpoint` returns `text/plain` for 400/404/501 errors.
+This is consistent with the HKP tradition but inconsistent with what `application/problem+json`
+(RFC 7807) would offer.  The `ExceptionMapper` classes are already in place;
+switching the content type is deferred (saved for a dedicated commit).

--- a/docs/implementation-plan.adoc
+++ b/docs/implementation-plan.adoc
@@ -728,6 +728,10 @@ Operators cannot filter the audit log by key fingerprint.
 ==== Error response content type
 
 `LookupEndpoint` returns `text/plain` for 400/404/501 errors.
-This is consistent with the HKP tradition but inconsistent with what `application/problem+json`
-(RFC 7807) would offer.  The `ExceptionMapper` classes are already in place;
-switching the content type is deferred (saved for a dedicated commit).
+This is the correct behavior for HKP compatibility: HKP clients expect plain-text
+error bodies, so HKP endpoints should continue to produce `text/plain` rather than
+`application/problem+json`.  The deferred work is to make error handling consistent
+across the HKP surface (including the existing `ExceptionMapper` classes) so they
+also emit `text/plain` for HKP failures.  If RFC 7807 responses are introduced in
+the future, they should be limited to separate non-HKP/REST endpoints or explicit
+content negotiation, not replace HKP error responses.


### PR DESCRIPTION
- Architecture: ports table updated, section 9 added (verification flow), weak spots rewritten with concrete gaps, section 12 revised
- Implementation plan: mark completed items, add self-critique section (§9)