### PR TITLE
Add subkey cap with template-method verification chain

### DIFF
--- a/.github/AGENTS.adoc
+++ b/.github/AGENTS.adoc
@@ -156,6 +156,10 @@ Every mutating command is wrapped in a BTX lifecycle:
 * Do not add temporary hacks or broad fallbacks.
 * Keep names, formatting, and package structure consistent with nearby code.
 * Use `this.` when referencing instance fields in Java code.
+* Prefer non-nullability where possible; prefer null-object patterns where they fit the design.
+* Use `@Nullable` sparingly and only at boundaries that genuinely allow absence.
+* Prefer `Optional` instead of `@Nullable` for return types.
+* Never use `Optional` in fields, and avoid `Optional` parameters unless there is no cleaner API shape.
 * Avoid mixing docs, refactors, and behavior changes unless the task needs it.
 * After each Java or `pom.xml` change, run `./mvnw spotless:apply`.
 

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/ex/KeyValidationException.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/ex/KeyValidationException.java
@@ -15,6 +15,7 @@ public abstract sealed class KeyValidationException extends KeyServerException
                 KeyRevokedException,
                 NoVerifiableUidException,
                 InvalidAlgorithmException,
+                TooManySubkeysException,
                 TooManyVerifiableUidsException {
 
     protected KeyValidationException(String message, Optional<KeyFingerprint> fingerprint) {

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/ex/TooManySubkeysException.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/ex/TooManySubkeysException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.api.ex;
+
+import io.github.bmarwell.keyserver.common.ids.KeyFingerprint;
+import java.util.Optional;
+
+/// Thrown when a submitted key carries more subkeys than the server is willing
+/// to process during submission and later verified-UID publication.
+public final class TooManySubkeysException extends KeyValidationException {
+
+    public TooManySubkeysException(String message, KeyFingerprint fingerprint) {
+        super(message, Optional.of(fingerprint));
+    }
+
+    public TooManySubkeysException(String message) {
+        super(message, Optional.empty());
+    }
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AbstractKeyServerCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AbstractKeyServerCommandHandler.java
@@ -8,12 +8,18 @@ package io.github.bmarwell.keyserver.application.core.cmdhandler;
 import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommandResponse;
+import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.CommandVerificationRegistry;
 
-public abstract class AbstractKeyServerCommandHandler<T extends KeyServerCommand> implements CommandHandler<T> {
+public abstract class AbstractKeyServerCommandHandler<T extends KeyServerCommand, V> implements CommandHandler<T> {
 
-    public KeyServerCommandResponse execute(KeyServerCommand command, CommandCallerContext callerContext) {
-        return doExecute((T) command, callerContext);
+    @Override
+    public final KeyServerCommandResponse execute(KeyServerCommand command, CommandCallerContext callerContext) {
+        T typedCommand = (T) command;
+        V verification = this.verificationRegistry().verify(typedCommand, callerContext);
+        return this.doExecute(typedCommand, verification, callerContext);
     }
 
-    abstract KeyServerCommandResponse doExecute(T command, CommandCallerContext callerContext);
+    protected abstract CommandVerificationRegistry<T, V> verificationRegistry();
+
+    abstract KeyServerCommandResponse doExecute(T command, V verification, CommandCallerContext callerContext);
 }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
@@ -9,53 +9,32 @@ import io.github.bmarwell.keyserver.application.api.commands.AddKeyToVerificatio
 import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommandResponse;
-import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
-import io.github.bmarwell.keyserver.application.api.ex.KeyRevokedException;
-import io.github.bmarwell.keyserver.application.api.ex.NoVerifiableUidException;
-import io.github.bmarwell.keyserver.application.api.ex.TooManyVerifiableUidsException;
+import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.CommandVerificationRegistry;
+import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.KeySubmissionVerifier;
 import io.github.bmarwell.keyserver.application.port.notification.VerificationNotificationPort;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationRequest;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.HexFormat;
-import java.util.Iterator;
-import java.util.List;
-import org.bouncycastle.openpgp.PGPException;
-import org.bouncycastle.openpgp.PGPPublicKey;
-import org.bouncycastle.openpgp.PGPPublicKeyRing;
-import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
-import org.bouncycastle.openpgp.PGPUtil;
-import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jspecify.annotations.Nullable;
 
 /// Handles the {@link AddKeyToVerificationQueueCommand}.
 ///
 /// ## What this handler does
 ///
-/// 1. Parses the ASCII-armored key text with Bouncycastle.
-/// 2. For each key ring in the submission, locates the master key.
-/// 3. Rejects keys that are revoked (has a direct-key revocation signature).
-/// 4. Collects only the UIDs that contain an email address (heuristic: must
-///    have exactly one `@`, no whitespace or control characters; the full
-///    `<local@domain>` form inside angle brackets is also supported).
-/// 5. Throws {@link NoVerifiableUidException} if no email-bearing UID survives.
-/// 6. Enqueues one {@link VerificationRequest} per surviving UID via the
+/// 1. Verifies and prepares the ASCII-armored key submission.
+/// 2. Enqueues one {@link VerificationRequest} per surviving UID via the
 ///    {@link VerificationQueueRepository} port.  The TSID returned by the
 ///    adapter is used to construct the verification URI.
-/// 7. Notifies via {@link VerificationNotificationPort} (first iteration: logs
+/// 3. Notifies via {@link VerificationNotificationPort} (first iteration: logs
 ///    the URI; later: sends email).
 ///
 /// ## Expiry
 ///
-/// Tokens expire after {@value #TOKEN_TTL_HOURS} hours by default.  A future
-/// iteration will make this configurable via MicroProfile Config.
+/// Tokens expire after {@value #TOKEN_TTL_HOURS} hours by default.
 ///
 /// ## Caller context
 ///
@@ -65,10 +44,12 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 /// is present to satisfy the handler contract (see implementation-plan §8.7).
 @RequestScoped
 public class AddKeyToVerificationQueueCommandHandler
-        extends AbstractKeyServerCommandHandler<AddKeyToVerificationQueueCommand> {
+        extends AbstractKeyServerCommandHandler<
+                AddKeyToVerificationQueueCommand, KeySubmissionVerifier.VerifiedKeySubmission> {
 
     static final int TOKEN_TTL_HOURS = 24;
     static final int DEFAULT_MAX_KEY_BYTES = 128 * 1024;
+    static final int MAX_SUBKEYS = 50;
     static final String MAX_KEY_BYTES_CONFIG_KEY = "keyserver.pks.max-key-bytes";
 
     /// Maximum number of email-bearing UIDs accepted from a single key submission.
@@ -86,7 +67,6 @@ public class AddKeyToVerificationQueueCommandHandler
     /// - Each UID triggers one outbound email and one user interaction, so the cap
     ///   also limits resource consumption during the verification flow itself.
     ///
-    /// @see TooManyVerifiableUidsException
     static final int MAX_EMAIL_UIDS = 20;
 
     @Inject
@@ -99,130 +79,48 @@ public class AddKeyToVerificationQueueCommandHandler
     @ConfigProperty(name = MAX_KEY_BYTES_CONFIG_KEY, defaultValue = "" + DEFAULT_MAX_KEY_BYTES)
     int maxKeyBytes;
 
+    private @Nullable CommandVerificationRegistry<
+                    AddKeyToVerificationQueueCommand, KeySubmissionVerifier.VerifiedKeySubmission>
+            keySubmissionVerifier;
+
     @Override
     public <C extends KeyServerCommand> boolean canHandle(C command) {
         return command instanceof AddKeyToVerificationQueueCommand;
     }
 
     @Override
-    KeyServerCommandResponse doExecute(AddKeyToVerificationQueueCommand command, CommandCallerContext callerContext) {
-        if (command.keyText() == null || command.keyText().isBlank()) {
-            throw new KeyParsingException("keytext must not be null or blank");
+    protected CommandVerificationRegistry<AddKeyToVerificationQueueCommand, KeySubmissionVerifier.VerifiedKeySubmission>
+            verificationRegistry() {
+        if (this.keySubmissionVerifier != null) {
+            return this.keySubmissionVerifier;
         }
+        return new KeySubmissionVerifier(this.maxKeyBytes, DEFAULT_MAX_KEY_BYTES, MAX_EMAIL_UIDS, MAX_SUBKEYS);
+    }
+
+    @Override
+    KeyServerCommandResponse doExecute(
+            AddKeyToVerificationQueueCommand command,
+            KeySubmissionVerifier.VerifiedKeySubmission verification,
+            CommandCallerContext callerContext) {
         String keyText = command.keyText();
-        int limitBytes = this.effectiveMaxKeyBytes();
-        if (keyText.length() > limitBytes) {
-            throw new KeyParsingException("Key submission exceeds maximum allowed size");
-        }
-        byte[] keyTextBytes = keyText.getBytes(StandardCharsets.UTF_8);
-        if (keyTextBytes.length > limitBytes) {
-            throw new KeyParsingException("Key submission exceeds maximum allowed size");
-        }
-        PGPPublicKeyRingCollection keyRingCollection = this.parseKeyText(keyTextBytes);
-
-        if (!keyRingCollection.iterator().hasNext()) {
-            throw new KeyParsingException("Key text contains no valid OpenPGP key rings");
-        }
-
-        for (Iterator<PGPPublicKeyRing> rings = keyRingCollection.getKeyRings(); rings.hasNext(); ) {
-            PGPPublicKeyRing keyRing = rings.next();
-            this.processKeyRing(keyRing, keyText);
-        }
+        this.enqueueVerificationRequests(keyText, verification);
 
         return KeyServerCommandResponse.success();
     }
 
-    private void processKeyRing(PGPPublicKeyRing keyRing, String armoredKey) {
-        PGPPublicKey masterKey = keyRing.getPublicKey();
-
-        if (masterKey.hasRevocation()) {
-            throw new KeyRevokedException(
-                    "Master key %s is revoked".formatted(fingerprintHex(masterKey)), () -> fingerprintHex(masterKey));
-        }
-
-        List<String> emailUids = this.collectEmailUids(masterKey);
-        if (emailUids.isEmpty()) {
-            throw new NoVerifiableUidException(
-                    "Key %s has no UIDs with a verifiable email address".formatted(fingerprintHex(masterKey)));
-        }
-        if (emailUids.size() > MAX_EMAIL_UIDS) {
-            throw new TooManyVerifiableUidsException(
-                    "Key %s has %d email UIDs, exceeding the limit of %d — submission rejected as potential DoS"
-                            .formatted(fingerprintHex(masterKey), emailUids.size(), MAX_EMAIL_UIDS));
-        }
-
-        String fingerprint = fingerprintHex(masterKey);
+    private void enqueueVerificationRequests(
+            String armoredKey, KeySubmissionVerifier.VerifiedKeySubmission verifiedSubmission) {
         OffsetDateTime expiresAt = OffsetDateTime.now().plusHours(TOKEN_TTL_HOURS);
-
-        for (String uid : emailUids) {
-            String email = this.extractEmail(uid);
-            var request = new VerificationRequest(fingerprint, uid, email, armoredKey, expiresAt);
-            long tsid = this.verificationQueueRepository.enqueue(request);
-            URI verificationUri = this.buildVerificationUri(tsid);
-            this.notificationPort.notifyPendingVerification(email, fingerprint, verificationUri);
-        }
-    }
-
-    private PGPPublicKeyRingCollection parseKeyText(byte[] keyBytes) {
-        try {
-            try (var decoderStream = PGPUtil.getDecoderStream(new ByteArrayInputStream(keyBytes))) {
-                return new PGPPublicKeyRingCollection(decoderStream, new BcKeyFingerprintCalculator());
-            }
-        } catch (IOException | PGPException e) {
-            throw new KeyParsingException("Failed to parse PGP key: " + e.getMessage(), e);
-        }
-    }
-
-    List<String> collectEmailUids(PGPPublicKey masterKey) {
-        List<String> emailUids = new ArrayList<>();
-        for (Iterator<String> userIds = masterKey.getUserIDs(); userIds.hasNext(); ) {
-            String uid = userIds.next();
-            if (this.containsEmail(uid)) {
-                emailUids.add(uid);
+        for (KeySubmissionVerifier.VerifiedKeyRing verifiedKeyRing : verifiedSubmission.verifiedKeyRings()) {
+            String fingerprint = verifiedKeyRing.fingerprint();
+            for (String emailUid : verifiedKeyRing.emailUids()) {
+                String email = KeySubmissionVerifier.extractEmail(emailUid);
+                var request = new VerificationRequest(fingerprint, emailUid, email, armoredKey, expiresAt);
+                long tsid = this.verificationQueueRepository.enqueue(request);
+                URI verificationUri = this.buildVerificationUri(tsid);
+                this.notificationPort.notifyPendingVerification(email, fingerprint, verificationUri);
             }
         }
-        return emailUids;
-    }
-
-    private boolean containsEmail(String uid) {
-        return this.extractEmail(uid) != null;
-    }
-
-    /// Extracts the email address from a UID string.
-    ///
-    /// Supports both `Name <email@example.com>` and bare `email@example.com` forms.
-    /// Returns `null` if no valid email pattern is found.
-    private String extractEmail(String uid) {
-        if (uid == null || uid.isBlank()) {
-            return null;
-        }
-        int lt = uid.indexOf('<');
-        int gt = uid.indexOf('>');
-        if (lt >= 0 && gt > lt) {
-            String candidate = uid.substring(lt + 1, gt).strip();
-            return this.isValidEmail(candidate) ? candidate : null;
-        }
-        // bare address
-        return this.isValidEmail(uid.strip()) ? uid.strip() : null;
-    }
-
-    private boolean isValidEmail(String candidate) {
-        if (candidate == null || candidate.isEmpty()) {
-            return false;
-        }
-        // Reject any whitespace or control characters to prevent log injection.
-        for (int i = 0; i < candidate.length(); i++) {
-            char c = candidate.charAt(i);
-            if (c <= ' ' || c == 127) {
-                return false;
-            }
-        }
-        int at = candidate.indexOf('@');
-        return at > 0 && at == candidate.lastIndexOf('@') && at < candidate.length() - 1;
-    }
-
-    private String fingerprintHex(PGPPublicKey key) {
-        return HexFormat.of().formatHex(key.getFingerprint()).toUpperCase();
     }
 
     /// Builds the verification URI from a TSID token.
@@ -242,11 +140,13 @@ public class AddKeyToVerificationQueueCommandHandler
         this.notificationPort = notificationPort;
     }
 
-    void setMaxKeyBytes(int maxKeyBytes) {
-        this.maxKeyBytes = maxKeyBytes;
+    void setKeySubmissionVerifier(
+            CommandVerificationRegistry<AddKeyToVerificationQueueCommand, KeySubmissionVerifier.VerifiedKeySubmission>
+                    keySubmissionVerifier) {
+        this.keySubmissionVerifier = keySubmissionVerifier;
     }
 
-    private int effectiveMaxKeyBytes() {
-        return this.maxKeyBytes > 0 ? this.maxKeyBytes : DEFAULT_MAX_KEY_BYTES;
+    void setMaxKeyBytes(int maxKeyBytes) {
+        this.maxKeyBytes = maxKeyBytes;
     }
 }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
@@ -19,7 +19,6 @@ import jakarta.inject.Inject;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jspecify.annotations.Nullable;
 
 /// Handles the {@link AddKeyToVerificationQueueCommand}.
 ///
@@ -79,9 +78,9 @@ public class AddKeyToVerificationQueueCommandHandler
     @ConfigProperty(name = MAX_KEY_BYTES_CONFIG_KEY, defaultValue = "" + DEFAULT_MAX_KEY_BYTES)
     int maxKeyBytes;
 
-    private @Nullable CommandVerificationRegistry<
-                    AddKeyToVerificationQueueCommand, KeySubmissionVerifier.VerifiedKeySubmission>
-            keySubmissionVerifier;
+    private CommandVerificationRegistry<AddKeyToVerificationQueueCommand, KeySubmissionVerifier.VerifiedKeySubmission>
+            keySubmissionVerifier = this.newKeySubmissionVerifier(DEFAULT_MAX_KEY_BYTES);
+    private boolean useCustomKeySubmissionVerifier;
 
     @Override
     public <C extends KeyServerCommand> boolean canHandle(C command) {
@@ -91,10 +90,10 @@ public class AddKeyToVerificationQueueCommandHandler
     @Override
     protected CommandVerificationRegistry<AddKeyToVerificationQueueCommand, KeySubmissionVerifier.VerifiedKeySubmission>
             verificationRegistry() {
-        if (this.keySubmissionVerifier != null) {
+        if (this.useCustomKeySubmissionVerifier) {
             return this.keySubmissionVerifier;
         }
-        return new KeySubmissionVerifier(this.maxKeyBytes, DEFAULT_MAX_KEY_BYTES, MAX_EMAIL_UIDS, MAX_SUBKEYS);
+        return this.newKeySubmissionVerifier(this.maxKeyBytes);
     }
 
     @Override
@@ -102,24 +101,24 @@ public class AddKeyToVerificationQueueCommandHandler
             AddKeyToVerificationQueueCommand command,
             KeySubmissionVerifier.VerifiedKeySubmission verification,
             CommandCallerContext callerContext) {
-        String keyText = command.keyText();
-        this.enqueueVerificationRequests(keyText, verification);
+        this.enqueueVerificationRequests(verification);
 
         return KeyServerCommandResponse.success();
     }
 
-    private void enqueueVerificationRequests(
-            String armoredKey, KeySubmissionVerifier.VerifiedKeySubmission verifiedSubmission) {
+    private void enqueueVerificationRequests(KeySubmissionVerifier.VerifiedKeySubmission verifiedSubmission) {
         OffsetDateTime expiresAt = OffsetDateTime.now().plusHours(TOKEN_TTL_HOURS);
-        for (KeySubmissionVerifier.VerifiedKeyRing verifiedKeyRing : verifiedSubmission.verifiedKeyRings()) {
-            String fingerprint = verifiedKeyRing.fingerprint();
-            for (String emailUid : verifiedKeyRing.emailUids()) {
-                String email = KeySubmissionVerifier.extractEmail(emailUid);
-                var request = new VerificationRequest(fingerprint, emailUid, email, armoredKey, expiresAt);
-                long tsid = this.verificationQueueRepository.enqueue(request);
-                URI verificationUri = this.buildVerificationUri(tsid);
-                this.notificationPort.notifyPendingVerification(email, fingerprint, verificationUri);
-            }
+        for (KeySubmissionVerifier.VerifiedKeyIdentity verifiedIdentity : verifiedSubmission.verifiedIdentities()) {
+            var request = new VerificationRequest(
+                    verifiedIdentity.fingerprint(),
+                    verifiedIdentity.uidRaw(),
+                    verifiedIdentity.uidEmail(),
+                    verifiedSubmission.armoredKey(),
+                    expiresAt);
+            long tsid = this.verificationQueueRepository.enqueue(request);
+            URI verificationUri = this.buildVerificationUri(tsid);
+            this.notificationPort.notifyPendingVerification(
+                    verifiedIdentity.uidEmail(), verifiedIdentity.fingerprint(), verificationUri);
         }
     }
 
@@ -144,9 +143,14 @@ public class AddKeyToVerificationQueueCommandHandler
             CommandVerificationRegistry<AddKeyToVerificationQueueCommand, KeySubmissionVerifier.VerifiedKeySubmission>
                     keySubmissionVerifier) {
         this.keySubmissionVerifier = keySubmissionVerifier;
+        this.useCustomKeySubmissionVerifier = true;
     }
 
     void setMaxKeyBytes(int maxKeyBytes) {
         this.maxKeyBytes = maxKeyBytes;
+    }
+
+    private KeySubmissionVerifier newKeySubmissionVerifier(int configuredMaxKeyBytes) {
+        return new KeySubmissionVerifier(configuredMaxKeyBytes, DEFAULT_MAX_KEY_BYTES, MAX_EMAIL_UIDS, MAX_SUBKEYS);
     }
 }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
@@ -66,9 +66,9 @@ public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<Ver
     @Override
     KeyServerCommandResponse doExecute(
             VerifyUidCommand command, NoCommandVerification verification, CommandCallerContext callerContext) {
-        long tokenId = parseToken(command.token());
+        long tokenId = this.parseToken(command.token());
 
-        VerificationEntry entry = verificationQueueRepository
+        VerificationEntry entry = this.verificationQueueRepository
                 .findPendingById(tokenId)
                 .orElseThrow(() -> new TokenInvalidException(
                         // Do not echo the token value into the exception message.
@@ -81,8 +81,9 @@ public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<Ver
             throw new TokenExpiredException("Verification token has expired for fingerprint " + entry.fingerprint());
         }
 
-        verificationQueueRepository.markVerified(tokenId);
-        keyRepository.publishVerifiedUid(entry.fingerprint(), entry.uidRaw(), entry.uidEmail(), entry.armoredKey());
+        this.verificationQueueRepository.markVerified(tokenId);
+        this.keyRepository.publishVerifiedUid(
+                entry.fingerprint(), entry.uidRaw(), entry.uidEmail(), entry.armoredKey());
 
         return KeyServerCommandResponse.success();
     }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
@@ -11,6 +11,9 @@ import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommandRes
 import io.github.bmarwell.keyserver.application.api.commands.VerifyUidCommand;
 import io.github.bmarwell.keyserver.application.api.ex.TokenExpiredException;
 import io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException;
+import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.CommandVerificationRegistry;
+import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.NoCommandVerification;
+import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.NoOpCommandVerificationRegistry;
 import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationEntry;
@@ -39,7 +42,10 @@ import java.time.OffsetDateTime;
 /// The `CommandCallerContext` is threaded through for audit consistency but this
 /// handler does not require the IP directly.
 @RequestScoped
-public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<VerifyUidCommand> {
+public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<VerifyUidCommand, NoCommandVerification> {
+
+    private final CommandVerificationRegistry<VerifyUidCommand, NoCommandVerification> noOpVerificationRegistry =
+            new NoOpCommandVerificationRegistry<>();
 
     @Inject
     VerificationQueueRepository verificationQueueRepository;
@@ -53,7 +59,13 @@ public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<Ver
     }
 
     @Override
-    KeyServerCommandResponse doExecute(VerifyUidCommand command, CommandCallerContext callerContext) {
+    protected CommandVerificationRegistry<VerifyUidCommand, NoCommandVerification> verificationRegistry() {
+        return this.noOpVerificationRegistry;
+    }
+
+    @Override
+    KeyServerCommandResponse doExecute(
+            VerifyUidCommand command, NoCommandVerification verification, CommandCallerContext callerContext) {
         long tokenId = parseToken(command.token());
 
         VerificationEntry entry = verificationQueueRepository

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/CommandVerificationRegistry.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/CommandVerificationRegistry.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler.verification;
+
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
+import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
+
+/// Central verification entry point for one command type.
+public interface CommandVerificationRegistry<T extends KeyServerCommand, V> {
+
+    V verify(T command, CommandCallerContext callerContext);
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyRingVerifier.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyRingVerifier.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler.verification;
+
+import io.github.bmarwell.keyserver.application.api.ex.KeyRevokedException;
+import io.github.bmarwell.keyserver.application.api.ex.NoVerifiableUidException;
+import io.github.bmarwell.keyserver.application.api.ex.TooManySubkeysException;
+import io.github.bmarwell.keyserver.application.api.ex.TooManyVerifiableUidsException;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.Iterator;
+import java.util.List;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPPublicKeyRing;
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+
+/// Verifies parsed OpenPGP key rings against the server's add-path rules.
+public class KeyRingVerifier
+        implements VerificationStep<PGPPublicKeyRingCollection, KeySubmissionVerifier.VerifiedKeySubmission> {
+
+    private final int maxEmailUids;
+    private final int maxSubkeys;
+
+    public KeyRingVerifier(int maxEmailUids, int maxSubkeys) {
+        this.maxEmailUids = maxEmailUids;
+        this.maxSubkeys = maxSubkeys;
+    }
+
+    @Override
+    public KeySubmissionVerifier.VerifiedKeySubmission verify(PGPPublicKeyRingCollection keyRingCollection) {
+        List<KeySubmissionVerifier.VerifiedKeyRing> verifiedKeyRings = new ArrayList<>();
+        for (Iterator<PGPPublicKeyRing> rings = keyRingCollection.getKeyRings(); rings.hasNext(); ) {
+            verifiedKeyRings.add(this.verifyKeyRing(rings.next()));
+        }
+        return new KeySubmissionVerifier.VerifiedKeySubmission(List.copyOf(verifiedKeyRings));
+    }
+
+    KeySubmissionVerifier.VerifiedKeyRing verifyKeyRing(PGPPublicKeyRing keyRing) {
+        PGPPublicKey masterKey = keyRing.getPublicKey();
+        String fingerprint = this.fingerprintHex(masterKey);
+
+        if (masterKey.hasRevocation()) {
+            throw new KeyRevokedException("Master key %s is revoked".formatted(fingerprint), () -> fingerprint);
+        }
+
+        int subkeyCount = this.countSubkeys(keyRing);
+        if (subkeyCount > this.maxSubkeys) {
+            throw new TooManySubkeysException(
+                    "Key %s has %d subkeys, exceeding the limit of %d — submission rejected as potential DoS"
+                            .formatted(fingerprint, subkeyCount, this.maxSubkeys),
+                    () -> fingerprint);
+        }
+
+        List<String> emailUids = this.collectEmailUids(masterKey);
+        if (emailUids.isEmpty()) {
+            throw new NoVerifiableUidException(
+                    "Key %s has no UIDs with a verifiable email address".formatted(fingerprint));
+        }
+        if (emailUids.size() > this.maxEmailUids) {
+            throw new TooManyVerifiableUidsException(
+                    "Key %s has %d email UIDs, exceeding the limit of %d — submission rejected as potential DoS"
+                            .formatted(fingerprint, emailUids.size(), this.maxEmailUids));
+        }
+
+        return new KeySubmissionVerifier.VerifiedKeyRing(fingerprint, List.copyOf(emailUids));
+    }
+
+    List<String> collectEmailUids(PGPPublicKey masterKey) {
+        List<String> emailUids = new ArrayList<>();
+        for (Iterator<String> userIds = masterKey.getUserIDs(); userIds.hasNext(); ) {
+            String uid = userIds.next();
+            if (KeySubmissionVerifier.extractEmail(uid) != null) {
+                emailUids.add(uid);
+            }
+        }
+        return emailUids;
+    }
+
+    int countSubkeys(PGPPublicKeyRing keyRing) {
+        int subkeyCount = 0;
+        for (Iterator<PGPPublicKey> keys = keyRing.getPublicKeys(); keys.hasNext(); ) {
+            PGPPublicKey key = keys.next();
+            if (!key.isMasterKey()) {
+                subkeyCount++;
+            }
+        }
+        return subkeyCount;
+    }
+
+    private String fingerprintHex(PGPPublicKey key) {
+        return HexFormat.of().formatHex(key.getFingerprint()).toUpperCase();
+    }
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyRingVerifier.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyRingVerifier.java
@@ -15,11 +15,11 @@ import java.util.Iterator;
 import java.util.List;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
-import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
 
 /// Verifies parsed OpenPGP key rings against the server's add-path rules.
 public class KeyRingVerifier
-        implements VerificationStep<PGPPublicKeyRingCollection, KeySubmissionVerifier.VerifiedKeySubmission> {
+        implements VerificationStep<
+                KeySubmissionVerifier.VerifiedKeyMaterial, KeySubmissionVerifier.VerifiedKeySubmission> {
 
     private final int maxEmailUids;
     private final int maxSubkeys;
@@ -30,15 +30,19 @@ public class KeyRingVerifier
     }
 
     @Override
-    public KeySubmissionVerifier.VerifiedKeySubmission verify(PGPPublicKeyRingCollection keyRingCollection) {
-        List<KeySubmissionVerifier.VerifiedKeyRing> verifiedKeyRings = new ArrayList<>();
-        for (Iterator<PGPPublicKeyRing> rings = keyRingCollection.getKeyRings(); rings.hasNext(); ) {
-            verifiedKeyRings.add(this.verifyKeyRing(rings.next()));
+    public KeySubmissionVerifier.VerifiedKeySubmission verify(
+            KeySubmissionVerifier.VerifiedKeyMaterial verifiedKeyMaterial) {
+        List<KeySubmissionVerifier.VerifiedKeyIdentity> verifiedIdentities = new ArrayList<>();
+        for (Iterator<PGPPublicKeyRing> rings =
+                        verifiedKeyMaterial.keyRingCollection().getKeyRings();
+                rings.hasNext(); ) {
+            verifiedIdentities.addAll(this.verifyKeyRing(rings.next()));
         }
-        return new KeySubmissionVerifier.VerifiedKeySubmission(List.copyOf(verifiedKeyRings));
+        return new KeySubmissionVerifier.VerifiedKeySubmission(
+                verifiedKeyMaterial.armoredKey(), List.copyOf(verifiedIdentities));
     }
 
-    KeySubmissionVerifier.VerifiedKeyRing verifyKeyRing(PGPPublicKeyRing keyRing) {
+    List<KeySubmissionVerifier.VerifiedKeyIdentity> verifyKeyRing(PGPPublicKeyRing keyRing) {
         PGPPublicKey masterKey = keyRing.getPublicKey();
         String fingerprint = this.fingerprintHex(masterKey);
 
@@ -57,7 +61,7 @@ public class KeyRingVerifier
         List<String> emailUids = this.collectEmailUids(masterKey);
         if (emailUids.isEmpty()) {
             throw new NoVerifiableUidException(
-                    "Key %s has no UIDs with a verifiable email address".formatted(fingerprint));
+                    "Key %s has no UIDs with a verifiable email address".formatted(fingerprint), () -> fingerprint);
         }
         if (emailUids.size() > this.maxEmailUids) {
             throw new TooManyVerifiableUidsException(
@@ -65,14 +69,19 @@ public class KeyRingVerifier
                             .formatted(fingerprint, emailUids.size(), this.maxEmailUids));
         }
 
-        return new KeySubmissionVerifier.VerifiedKeyRing(fingerprint, List.copyOf(emailUids));
+        return emailUids.stream()
+                .map(uidRaw -> new KeySubmissionVerifier.VerifiedKeyIdentity(
+                        fingerprint,
+                        uidRaw,
+                        KeySubmissionVerifier.extractEmail(uidRaw).orElseThrow()))
+                .toList();
     }
 
     List<String> collectEmailUids(PGPPublicKey masterKey) {
         List<String> emailUids = new ArrayList<>();
         for (Iterator<String> userIds = masterKey.getUserIDs(); userIds.hasNext(); ) {
             String uid = userIds.next();
-            if (KeySubmissionVerifier.extractEmail(uid) != null) {
+            if (KeySubmissionVerifier.extractEmail(uid).isPresent()) {
                 emailUids.add(uid);
             }
         }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeySubmissionVerifier.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeySubmissionVerifier.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler.verification;
+
+import io.github.bmarwell.keyserver.application.api.commands.AddKeyToVerificationQueueCommand;
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
+import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
+import java.util.List;
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+
+/// Runs the add-path verification chain for an armored key submission.
+public class KeySubmissionVerifier
+        implements CommandVerificationRegistry<
+                AddKeyToVerificationQueueCommand, KeySubmissionVerifier.VerifiedKeySubmission> {
+
+    private final int configuredMaxKeyBytes;
+    private final int defaultMaxKeyBytes;
+    private final VerificationStep<KeyTextSizeValidator.Input, byte[]> keyTextSizeValidator;
+    private final VerificationStep<byte[], PGPPublicKeyRingCollection> keyTextParser;
+    private final VerificationStep<PGPPublicKeyRingCollection, VerifiedKeySubmission> keyRingVerifier;
+
+    public KeySubmissionVerifier(int configuredMaxKeyBytes, int defaultMaxKeyBytes, int maxEmailUids, int maxSubkeys) {
+        this(
+                configuredMaxKeyBytes,
+                defaultMaxKeyBytes,
+                new KeyTextSizeValidator(),
+                new KeyTextParser(),
+                new KeyRingVerifier(maxEmailUids, maxSubkeys));
+    }
+
+    KeySubmissionVerifier(
+            int configuredMaxKeyBytes,
+            int defaultMaxKeyBytes,
+            VerificationStep<KeyTextSizeValidator.Input, byte[]> keyTextSizeValidator,
+            VerificationStep<byte[], PGPPublicKeyRingCollection> keyTextParser,
+            VerificationStep<PGPPublicKeyRingCollection, VerifiedKeySubmission> keyRingVerifier) {
+        this.configuredMaxKeyBytes = configuredMaxKeyBytes;
+        this.defaultMaxKeyBytes = defaultMaxKeyBytes;
+        this.keyTextSizeValidator = keyTextSizeValidator;
+        this.keyTextParser = keyTextParser;
+        this.keyRingVerifier = keyRingVerifier;
+    }
+
+    @Override
+    public VerifiedKeySubmission verify(AddKeyToVerificationQueueCommand command, CommandCallerContext callerContext) {
+        byte[] keyTextBytes = this.keyTextSizeValidator.verify(
+                new KeyTextSizeValidator.Input(command.keyText(), this.configuredMaxKeyBytes, this.defaultMaxKeyBytes));
+        PGPPublicKeyRingCollection keyRingCollection = this.keyTextParser.verify(keyTextBytes);
+
+        if (!keyRingCollection.iterator().hasNext()) {
+            throw new KeyParsingException("Key text contains no valid OpenPGP key rings");
+        }
+
+        return this.keyRingVerifier.verify(keyRingCollection);
+    }
+
+    public static String extractEmail(String uid) {
+        if (uid == null || uid.isBlank()) {
+            return null;
+        }
+        int lt = uid.indexOf('<');
+        int gt = uid.indexOf('>');
+        if (lt >= 0 && gt > lt) {
+            String candidate = uid.substring(lt + 1, gt).strip();
+            return isValidEmail(candidate) ? candidate : null;
+        }
+        return isValidEmail(uid.strip()) ? uid.strip() : null;
+    }
+
+    private static boolean isValidEmail(String candidate) {
+        if (candidate == null || candidate.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < candidate.length(); i++) {
+            char c = candidate.charAt(i);
+            if (c <= ' ' || c == 127) {
+                return false;
+            }
+        }
+        int at = candidate.indexOf('@');
+        return at > 0 && at == candidate.lastIndexOf('@') && at < candidate.length() - 1;
+    }
+
+    public record VerifiedKeySubmission(List<VerifiedKeyRing> verifiedKeyRings) {}
+
+    public record VerifiedKeyRing(String fingerprint, List<String> emailUids) {}
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeySubmissionVerifier.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeySubmissionVerifier.java
@@ -9,6 +9,8 @@ import io.github.bmarwell.keyserver.application.api.commands.AddKeyToVerificatio
 import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
 
 /// Runs the add-path verification chain for an armored key submission.
@@ -20,7 +22,7 @@ public class KeySubmissionVerifier
     private final int defaultMaxKeyBytes;
     private final VerificationStep<KeyTextSizeValidator.Input, byte[]> keyTextSizeValidator;
     private final VerificationStep<byte[], PGPPublicKeyRingCollection> keyTextParser;
-    private final VerificationStep<PGPPublicKeyRingCollection, VerifiedKeySubmission> keyRingVerifier;
+    private final VerificationStep<VerifiedKeyMaterial, VerifiedKeySubmission> keyRingVerifier;
 
     public KeySubmissionVerifier(int configuredMaxKeyBytes, int defaultMaxKeyBytes, int maxEmailUids, int maxSubkeys) {
         this(
@@ -36,7 +38,7 @@ public class KeySubmissionVerifier
             int defaultMaxKeyBytes,
             VerificationStep<KeyTextSizeValidator.Input, byte[]> keyTextSizeValidator,
             VerificationStep<byte[], PGPPublicKeyRingCollection> keyTextParser,
-            VerificationStep<PGPPublicKeyRingCollection, VerifiedKeySubmission> keyRingVerifier) {
+            VerificationStep<VerifiedKeyMaterial, VerifiedKeySubmission> keyRingVerifier) {
         this.configuredMaxKeyBytes = configuredMaxKeyBytes;
         this.defaultMaxKeyBytes = defaultMaxKeyBytes;
         this.keyTextSizeValidator = keyTextSizeValidator;
@@ -48,26 +50,28 @@ public class KeySubmissionVerifier
     public VerifiedKeySubmission verify(AddKeyToVerificationQueueCommand command, CommandCallerContext callerContext) {
         byte[] keyTextBytes = this.keyTextSizeValidator.verify(
                 new KeyTextSizeValidator.Input(command.keyText(), this.configuredMaxKeyBytes, this.defaultMaxKeyBytes));
+        String armoredKey = Objects.requireNonNull(command.keyText(), "Verified key text must be non-null");
         PGPPublicKeyRingCollection keyRingCollection = this.keyTextParser.verify(keyTextBytes);
 
         if (!keyRingCollection.iterator().hasNext()) {
             throw new KeyParsingException("Key text contains no valid OpenPGP key rings");
         }
 
-        return this.keyRingVerifier.verify(keyRingCollection);
+        return this.keyRingVerifier.verify(new VerifiedKeyMaterial(armoredKey, keyRingCollection));
     }
 
-    public static String extractEmail(String uid) {
+    public static Optional<String> extractEmail(String uid) {
         if (uid == null || uid.isBlank()) {
-            return null;
+            return Optional.empty();
         }
         int lt = uid.indexOf('<');
         int gt = uid.indexOf('>');
         if (lt >= 0 && gt > lt) {
             String candidate = uid.substring(lt + 1, gt).strip();
-            return isValidEmail(candidate) ? candidate : null;
+            return isValidEmail(candidate) ? Optional.of(candidate) : Optional.empty();
         }
-        return isValidEmail(uid.strip()) ? uid.strip() : null;
+        String candidate = uid.strip();
+        return isValidEmail(candidate) ? Optional.of(candidate) : Optional.empty();
     }
 
     private static boolean isValidEmail(String candidate) {
@@ -84,7 +88,9 @@ public class KeySubmissionVerifier
         return at > 0 && at == candidate.lastIndexOf('@') && at < candidate.length() - 1;
     }
 
-    public record VerifiedKeySubmission(List<VerifiedKeyRing> verifiedKeyRings) {}
+    public record VerifiedKeySubmission(String armoredKey, List<VerifiedKeyIdentity> verifiedIdentities) {}
 
-    public record VerifiedKeyRing(String fingerprint, List<String> emailUids) {}
+    record VerifiedKeyMaterial(String armoredKey, PGPPublicKeyRingCollection keyRingCollection) {}
+
+    public record VerifiedKeyIdentity(String fingerprint, String uidRaw, String uidEmail) {}
 }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyTextParser.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyTextParser.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler.verification;
+
+import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+import org.bouncycastle.openpgp.PGPUtil;
+import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
+
+/// Parses validated armored key bytes into a Bouncy Castle key-ring collection.
+public class KeyTextParser implements VerificationStep<byte[], PGPPublicKeyRingCollection> {
+
+    @Override
+    public PGPPublicKeyRingCollection verify(byte[] keyBytes) {
+        try {
+            try (var decoderStream = PGPUtil.getDecoderStream(new ByteArrayInputStream(keyBytes))) {
+                return new PGPPublicKeyRingCollection(decoderStream, new BcKeyFingerprintCalculator());
+            }
+        } catch (IOException | PGPException e) {
+            throw new KeyParsingException("Failed to parse PGP key: " + e.getMessage(), e);
+        }
+    }
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyTextSizeValidator.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyTextSizeValidator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler.verification;
+
+import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
+import java.nio.charset.StandardCharsets;
+
+/// Validates the raw armored-key payload size before any OpenPGP parsing happens.
+public class KeyTextSizeValidator implements VerificationStep<KeyTextSizeValidator.Input, byte[]> {
+
+    @Override
+    public byte[] verify(Input input) {
+        String keyText = input.keyText();
+        if (keyText == null || keyText.isBlank()) {
+            throw new KeyParsingException("keytext must not be null or blank");
+        }
+
+        int effectiveMaxKeyBytes =
+                input.configuredMaxKeyBytes() > 0 ? input.configuredMaxKeyBytes() : input.defaultMaxKeyBytes();
+        if (keyText.length() > effectiveMaxKeyBytes) {
+            throw new KeyParsingException("Key submission exceeds maximum allowed size");
+        }
+
+        byte[] keyTextBytes = keyText.getBytes(StandardCharsets.UTF_8);
+        if (keyTextBytes.length > effectiveMaxKeyBytes) {
+            throw new KeyParsingException("Key submission exceeds maximum allowed size");
+        }
+
+        return keyTextBytes;
+    }
+
+    public record Input(String keyText, int configuredMaxKeyBytes, int defaultMaxKeyBytes) {}
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyTextSizeValidator.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyTextSizeValidator.java
@@ -7,6 +7,7 @@ package io.github.bmarwell.keyserver.application.core.cmdhandler.verification;
 
 import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
 import java.nio.charset.StandardCharsets;
+import org.jspecify.annotations.Nullable;
 
 /// Validates the raw armored-key payload size before any OpenPGP parsing happens.
 public class KeyTextSizeValidator implements VerificationStep<KeyTextSizeValidator.Input, byte[]> {
@@ -32,5 +33,5 @@ public class KeyTextSizeValidator implements VerificationStep<KeyTextSizeValidat
         return keyTextBytes;
     }
 
-    public record Input(String keyText, int configuredMaxKeyBytes, int defaultMaxKeyBytes) {}
+    public record Input(@Nullable String keyText, int configuredMaxKeyBytes, int defaultMaxKeyBytes) {}
 }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/NoCommandVerification.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/NoCommandVerification.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler.verification;
+
+/// Marker result for handlers that currently have no pre-execution verification steps.
+public enum NoCommandVerification {
+    INSTANCE
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/NoOpCommandVerificationRegistry.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/NoOpCommandVerificationRegistry.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler.verification;
+
+import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
+import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
+
+/// Default verification registry used when a command handler has no explicit
+/// pre-execution verification steps yet.
+public final class NoOpCommandVerificationRegistry<T extends KeyServerCommand>
+        implements CommandVerificationRegistry<T, NoCommandVerification> {
+
+    @Override
+    public NoCommandVerification verify(T command, CommandCallerContext callerContext) {
+        return NoCommandVerification.INSTANCE;
+    }
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/VerificationStep.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/VerificationStep.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler.verification;
+
+/// Small reusable verification/validation step in a larger verification chain.
+public interface VerificationStep<I, O> {
+
+    O verify(I input);
+}

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandlerTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import io.github.bmarwell.keyserver.application.api.commands.AddKeyToVerificationQueueCommand;
 import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
-import io.github.bmarwell.keyserver.application.api.ex.TooManyVerifiableUidsException;
 import io.github.bmarwell.keyserver.application.port.notification.VerificationNotificationPort;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationRequest;
@@ -23,8 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.IntStream;
-import org.bouncycastle.openpgp.PGPPublicKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -89,7 +86,7 @@ class AddKeyToVerificationQueueCommandHandlerTest {
         String keyText = loadTestKey("test-key-with-email.asc");
         var command = new AddKeyToVerificationQueueCommand(keyText);
 
-        this.handler.doExecute(command, CommandCallerContext.empty());
+        this.handler.execute(command, CommandCallerContext.empty());
 
         // The test key has one UID: "Test Key <testkey@example.com>"
         assertThat(this.fakeRepo.received).hasSize(1);
@@ -102,7 +99,7 @@ class AddKeyToVerificationQueueCommandHandlerTest {
         String keyText = loadTestKey("test-key-with-email.asc");
         var command = new AddKeyToVerificationQueueCommand(keyText);
 
-        this.handler.doExecute(command, CommandCallerContext.empty());
+        this.handler.execute(command, CommandCallerContext.empty());
 
         assertThat(this.fakeNotification.received).hasSize(1);
         FakeNotificationPort.Notification note = this.fakeNotification.received.getFirst();
@@ -114,7 +111,7 @@ class AddKeyToVerificationQueueCommandHandlerTest {
     void rejects_null_key_text() {
         var command = new AddKeyToVerificationQueueCommand(null);
 
-        assertThatThrownBy(() -> this.handler.doExecute(command, CommandCallerContext.empty()))
+        assertThatThrownBy(() -> this.handler.execute(command, CommandCallerContext.empty()))
                 .isInstanceOf(KeyParsingException.class);
         assertThat(this.fakeRepo.received).isEmpty();
     }
@@ -123,7 +120,7 @@ class AddKeyToVerificationQueueCommandHandlerTest {
     void rejects_blank_key_text() {
         var command = new AddKeyToVerificationQueueCommand("   ");
 
-        assertThatThrownBy(() -> this.handler.doExecute(command, CommandCallerContext.empty()))
+        assertThatThrownBy(() -> this.handler.execute(command, CommandCallerContext.empty()))
                 .isInstanceOf(KeyParsingException.class);
         assertThat(this.fakeRepo.received).isEmpty();
     }
@@ -132,7 +129,7 @@ class AddKeyToVerificationQueueCommandHandlerTest {
     void rejects_garbage_key_text() {
         var command = new AddKeyToVerificationQueueCommand("not a pgp key");
 
-        assertThatThrownBy(() -> this.handler.doExecute(command, CommandCallerContext.empty()))
+        assertThatThrownBy(() -> this.handler.execute(command, CommandCallerContext.empty()))
                 .isInstanceOf(KeyParsingException.class);
         assertThat(this.fakeRepo.received).isEmpty();
         assertThat(this.fakeNotification.received).isEmpty();
@@ -147,7 +144,7 @@ class AddKeyToVerificationQueueCommandHandlerTest {
         var command = new AddKeyToVerificationQueueCommand(keyText);
 
         // when
-        this.handler.doExecute(command, CommandCallerContext.empty());
+        this.handler.execute(command, CommandCallerContext.empty());
 
         // then
         assertThat(this.fakeRepo.received).hasSize(1);
@@ -163,7 +160,7 @@ class AddKeyToVerificationQueueCommandHandlerTest {
         var command = new AddKeyToVerificationQueueCommand(keyText);
 
         // when
-        Throwable thrown = catchThrowable(() -> this.handler.doExecute(command, CommandCallerContext.empty()));
+        Throwable thrown = catchThrowable(() -> this.handler.execute(command, CommandCallerContext.empty()));
 
         // then
         assertThat(thrown).isInstanceOf(KeyParsingException.class).hasMessageContaining("maximum allowed size");
@@ -178,7 +175,7 @@ class AddKeyToVerificationQueueCommandHandlerTest {
         for (int configuredLimit : List.of(0, -1)) {
             this.handler.setMaxKeyBytes(configuredLimit);
 
-            assertThatThrownBy(() -> this.handler.doExecute(
+            assertThatThrownBy(() -> this.handler.execute(
                             new AddKeyToVerificationQueueCommand(oversizedAsciiKey), CommandCallerContext.empty()))
                     .isInstanceOf(KeyParsingException.class)
                     .hasMessageContaining("maximum allowed size");
@@ -193,53 +190,10 @@ class AddKeyToVerificationQueueCommandHandlerTest {
         String keyText = this.loadTestKey("test-key-with-email.asc");
         var command = new AddKeyToVerificationQueueCommand(keyText);
 
-        this.handler.doExecute(command, CommandCallerContext.empty());
+        this.handler.execute(command, CommandCallerContext.empty());
 
         String expectedTsidStr = Long.toUnsignedString(1000L); // first ID assigned by fake repo
         assertThat(this.fakeNotification.received.getFirst().verificationUri().toString())
                 .endsWith(expectedTsidStr);
-    }
-
-    // -----------------------------------------------------------------------
-    // Scenario 6: one million (well, MAX_EMAIL_UIDS + 1) email UIDs → rejected
-    // -----------------------------------------------------------------------
-
-    /**
-     * Subclass that overrides {@code collectEmailUids} to return a synthetic list
-     * of fake email addresses, bypassing the need for a real PGP key with many UIDs.
-     * This tests the DoS guard in isolation from the PGP parsing logic.
-     */
-    static class OverflowingHandler extends AddKeyToVerificationQueueCommandHandler {
-        private final int uidCount;
-
-        OverflowingHandler(int uidCount) {
-            this.uidCount = uidCount;
-        }
-
-        @Override
-        List<String> collectEmailUids(PGPPublicKey masterKey) {
-            return IntStream.range(0, uidCount)
-                    .mapToObj(i -> "user%d@example.com".formatted(i))
-                    .collect(java.util.stream.Collectors.toList());
-        }
-    }
-
-    @Test
-    void scenario6_too_many_email_uids_rejected() throws IOException {
-        int overLimit = AddKeyToVerificationQueueCommandHandler.MAX_EMAIL_UIDS + 1;
-        var overflowHandler = new OverflowingHandler(overLimit);
-        overflowHandler.setVerificationQueueRepository(this.fakeRepo);
-        overflowHandler.setNotificationPort(this.fakeNotification);
-
-        String keyText = this.loadTestKey("test-key-with-email.asc");
-        var command = new AddKeyToVerificationQueueCommand(keyText);
-
-        assertThatThrownBy(() -> overflowHandler.doExecute(command, CommandCallerContext.empty()))
-                .isInstanceOf(TooManyVerifiableUidsException.class)
-                .hasMessageContaining(String.valueOf(overLimit))
-                .hasMessageContaining(String.valueOf(AddKeyToVerificationQueueCommandHandler.MAX_EMAIL_UIDS));
-
-        assertThat(this.fakeRepo.received).isEmpty();
-        assertThat(this.fakeNotification.received).isEmpty();
     }
 }

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
@@ -153,7 +153,7 @@ class VerifyUidCommandHandlerTest {
     void scenario2_expired_token_throws_TokenExpiredException() {
         fakeQueue.put(TOKEN_1, expiredEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
 
-        assertThatThrownBy(() -> handler.doExecute(
+        assertThatThrownBy(() -> handler.execute(
                         new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty()))
                 .isInstanceOf(TokenExpiredException.class);
 
@@ -169,7 +169,7 @@ class VerifyUidCommandHandlerTest {
     void scenario3_single_email_clicked_publishes_key() {
         fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
 
-        handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+        handler.execute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
 
         assertThat(fakeKeys.published).hasSize(1);
         assertThat(fakeKeys.published.getFirst().uidEmail()).isEqualTo("alice@example.com");
@@ -182,10 +182,10 @@ class VerifyUidCommandHandlerTest {
         fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
 
         // First click succeeds
-        handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+        handler.execute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
 
         // Second click on the same token → invalid (consumed)
-        assertThatThrownBy(() -> handler.doExecute(
+        assertThatThrownBy(() -> handler.execute(
                         new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty()))
                 .isInstanceOf(TokenInvalidException.class);
 
@@ -204,10 +204,10 @@ class VerifyUidCommandHandlerTest {
         fakeQueue.put(TOKEN_2, expiredEntry(TOKEN_2, "Alice Work <work@corp.example>", "work@corp.example"));
 
         // First verification succeeds
-        handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+        handler.execute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
 
         // Second token has expired
-        assertThatThrownBy(() -> handler.doExecute(
+        assertThatThrownBy(() -> handler.execute(
                         new VerifyUidCommand(Long.toUnsignedString(TOKEN_2)), CommandCallerContext.empty()))
                 .isInstanceOf(TokenExpiredException.class);
 
@@ -226,8 +226,8 @@ class VerifyUidCommandHandlerTest {
         fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
         fakeQueue.put(TOKEN_2, pendingEntry(TOKEN_2, "Alice Work <work@corp.example>", "work@corp.example"));
 
-        handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
-        handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_2)), CommandCallerContext.empty());
+        handler.execute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+        handler.execute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_2)), CommandCallerContext.empty());
 
         assertThat(fakeKeys.published).hasSize(2);
         assertThat(fakeKeys.published)
@@ -242,7 +242,7 @@ class VerifyUidCommandHandlerTest {
 
     @Test
     void garbled_token_string_throws_TokenInvalidException() {
-        assertThatThrownBy(() -> handler.doExecute(new VerifyUidCommand("not-a-number"), CommandCallerContext.empty()))
+        assertThatThrownBy(() -> handler.execute(new VerifyUidCommand("not-a-number"), CommandCallerContext.empty()))
                 .isInstanceOf(TokenInvalidException.class);
         assertThat(fakeKeys.published).isEmpty();
     }
@@ -250,7 +250,7 @@ class VerifyUidCommandHandlerTest {
     @Test
     void unknown_token_throws_TokenInvalidException() {
         // Nothing in the fake queue
-        assertThatThrownBy(() -> handler.doExecute(
+        assertThatThrownBy(() -> handler.execute(
                         new VerifyUidCommand(Long.toUnsignedString(9_999L)), CommandCallerContext.empty()))
                 .isInstanceOf(TokenInvalidException.class);
         assertThat(fakeKeys.published).isEmpty();
@@ -287,7 +287,7 @@ class VerifyUidCommandHandlerTest {
         Thread t1 = new Thread(() -> {
             try {
                 start.await();
-                handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+                handler.execute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
             } catch (Throwable t) {
                 errors.add(t);
             } finally {
@@ -297,7 +297,7 @@ class VerifyUidCommandHandlerTest {
         Thread t2 = new Thread(() -> {
             try {
                 start.await();
-                handler.doExecute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_2)), CommandCallerContext.empty());
+                handler.execute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_2)), CommandCallerContext.empty());
             } catch (Throwable t) {
                 errors.add(t);
             } finally {

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyRingVerifierTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyRingVerifierTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core.cmdhandler.verification;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.bmarwell.keyserver.application.api.ex.TooManySubkeysException;
+import io.github.bmarwell.keyserver.application.api.ex.TooManyVerifiableUidsException;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPPublicKeyRing;
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
+import org.bouncycastle.openpgp.PGPUtil;
+import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
+import org.junit.jupiter.api.Test;
+
+class KeyRingVerifierTest {
+
+    private static final int MAX_EMAIL_UIDS = 20;
+    private static final int MAX_SUBKEYS = 50;
+
+    @Test
+    void rejects_key_ring_with_too_many_email_uids() throws Exception {
+        int overLimit = MAX_EMAIL_UIDS + 1;
+        KeyRingVerifier verifier = new KeyRingVerifier(MAX_EMAIL_UIDS, MAX_SUBKEYS) {
+            @Override
+            List<String> collectEmailUids(PGPPublicKey masterKey) {
+                return IntStream.range(0, overLimit)
+                        .mapToObj(i -> "user%d@example.com".formatted(i))
+                        .toList();
+            }
+        };
+
+        assertThatThrownBy(() -> verifier.verify(loadTestKeyRingCollection()))
+                .isInstanceOf(TooManyVerifiableUidsException.class)
+                .hasMessageContaining(String.valueOf(overLimit))
+                .hasMessageContaining(String.valueOf(MAX_EMAIL_UIDS));
+    }
+
+    @Test
+    void rejects_key_ring_with_too_many_subkeys() throws Exception {
+        int overLimit = MAX_SUBKEYS + 1;
+        KeyRingVerifier verifier = new KeyRingVerifier(MAX_EMAIL_UIDS, MAX_SUBKEYS) {
+            @Override
+            int countSubkeys(PGPPublicKeyRing keyRing) {
+                return overLimit;
+            }
+        };
+
+        assertThatThrownBy(() -> verifier.verify(loadTestKeyRingCollection()))
+                .isInstanceOf(TooManySubkeysException.class)
+                .hasMessageContaining(String.valueOf(overLimit))
+                .hasMessageContaining(String.valueOf(MAX_SUBKEYS));
+    }
+
+    private PGPPublicKeyRingCollection loadTestKeyRingCollection() throws Exception {
+        try (var stream = Objects.requireNonNull(getClass().getResourceAsStream("/pgp/test-key-with-email.asc"))) {
+            byte[] keyTextBytes = stream.readAllBytes();
+            try (var decoderStream = PGPUtil.getDecoderStream(new java.io.ByteArrayInputStream(keyTextBytes))) {
+                return new PGPPublicKeyRingCollection(decoderStream, new BcKeyFingerprintCalculator());
+            }
+        }
+    }
+}

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyRingVerifierTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/verification/KeyRingVerifierTest.java
@@ -36,7 +36,8 @@ class KeyRingVerifierTest {
             }
         };
 
-        assertThatThrownBy(() -> verifier.verify(loadTestKeyRingCollection()))
+        assertThatThrownBy(() -> verifier.verify(
+                        new KeySubmissionVerifier.VerifiedKeyMaterial("armored", loadTestKeyRingCollection())))
                 .isInstanceOf(TooManyVerifiableUidsException.class)
                 .hasMessageContaining(String.valueOf(overLimit))
                 .hasMessageContaining(String.valueOf(MAX_EMAIL_UIDS));
@@ -52,7 +53,8 @@ class KeyRingVerifierTest {
             }
         };
 
-        assertThatThrownBy(() -> verifier.verify(loadTestKeyRingCollection()))
+        assertThatThrownBy(() -> verifier.verify(
+                        new KeySubmissionVerifier.VerifiedKeyMaterial("armored", loadTestKeyRingCollection())))
                 .isInstanceOf(TooManySubkeysException.class)
                 .hasMessageContaining(String.valueOf(overLimit))
                 .hasMessageContaining(String.valueOf(MAX_SUBKEYS));

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -201,6 +201,9 @@ For lookup use cases, the flow is shorter:
   `PESSIMISTIC_WRITE` row lock — no application-level locking needed.
 * Third-party certification stripping is in place: only self-signatures are
   stored, preventing the server from becoming a social-graph database.
+* The add-path validation now follows a cleaner structure: the abstract handler
+  owns the pre-execution verification hook, while the add command delegates its
+  checks to a small verification registry/chain of single-purpose steps.
 
 == 9. Verification flow
 
@@ -243,6 +246,27 @@ at exactly the same moment:
    and re-strips.  The final committed state contains both UIDs.
 
 No UID is lost and no dirty state is written.
+
+=== Validation architecture
+
+Pre-execution command verification now has two layers:
+
+* **Template method** — `AbstractKeyServerCommandHandler.execute(...)` always runs
+  the command's verification registry before `doExecute(...)`.
+* **Verification registry** — a handler can provide a typed
+  `CommandVerificationRegistry<T, V>` that returns prepared verification output
+  for the actual business execution step.
+
+For `AddKeyToVerificationQueueCommand`, that registry is composed from small
+steps:
+
+* `KeyTextSizeValidator`
+* `KeyTextParser`
+* `KeyRingVerifier`
+
+This keeps "one class, one responsibility" while making it harder for a handler
+to forget validation entirely. A future enhancement is to migrate more commands
+onto the same pattern as their preconditions grow.
 
 == 8. Identity strategy
 

--- a/docs/implementation-plan.adoc
+++ b/docs/implementation-plan.adoc
@@ -481,8 +481,7 @@ try {
   business logic.
 * ✅ The add path now uses a verification registry/chain built from small
   verification steps (`KeyTextSizeValidator`, `KeyTextParser`, `KeyRingVerifier`).
-* Remaining handler hardening: subkey-count cap (#136) plus configurable token
-  TTL / remaining limits (#141).
+* Remaining handler hardening: configurable token TTL / remaining limits (#141).
 * Add `KeyServerQueryService` for read-only lookups (`@Transactional(READ_ONLY)`).
 
 === 6.4 `application/application-ports`

--- a/docs/implementation-plan.adoc
+++ b/docs/implementation-plan.adoc
@@ -476,6 +476,11 @@ try {
 * ✅ BTX lifecycle wiring complete.
 * ✅ `AddKeyToVerificationQueueCommandHandler` implemented.
 * ✅ Configurable add-path keytext size limit implemented via MicroProfile Config.
+* ✅ Command execution now has a template-method verification hook in
+  `AbstractKeyServerCommandHandler`: handlers execute verification first, then
+  business logic.
+* ✅ The add path now uses a verification registry/chain built from small
+  verification steps (`KeyTextSizeValidator`, `KeyTextParser`, `KeyRingVerifier`).
 * Remaining handler hardening: subkey-count cap (#136) plus configurable token
   TTL / remaining limits (#141).
 * Add `KeyServerQueryService` for read-only lookups (`@Transactional(READ_ONLY)`).
@@ -514,6 +519,24 @@ try {
   `application/problem+json` (#133).
 * Implement `KeyEndpoint` and `RepositoryEndpoint` stubs once the core flows
   work.
+
+=== 6.8 Future enhancement: command verification rollout
+
+The add command now uses **both** of the patterns discussed during #136:
+
+* a **template-method hook** in `AbstractKeyServerCommandHandler`, and
+* a **verification registry** composed of small verification steps.
+
+This should be the default direction for future command validation:
+
+* handlers should not inline large validation blocks in `doExecute(...)`
+* command-specific validation should live behind a typed
+  `CommandVerificationRegistry<T, V>`
+* reusable checks should be implemented as small `VerificationStep<I, O>` classes
+
+Future work can move more handlers (for example token verification or future REST
+write commands) onto the same structure as soon as they have enough pre-execution
+checks to justify it.
 
 == 7. Open Questions / Design Decisions
 


### PR DESCRIPTION
## Summary
- add a dedicated `TooManySubkeysException` and reject key submissions that exceed the subkey cap
- move the old #143 keytext-size guard and the new #136 subkey guard into a structured verification flow
- add a template-method verification hook in `AbstractKeyServerCommandHandler` and a typed verification registry interface
- document the new validation architecture and its future rollout in `docs/architecture.adoc` and `docs/implementation-plan.adoc`

## Verification design
- `AbstractKeyServerCommandHandler.execute(...)` now always runs a command verification registry before `doExecute(...)`
- `CommandVerificationRegistry<T, V>` is the typed registry interface for command-level pre-execution verification
- `VerificationStep<I, O>` is the small-step interface for reusable validators/parsers
- the add command uses `KeyTextSizeValidator` -> `KeyTextParser` -> `KeyRingVerifier`
- `VerifyUidCommandHandler` uses a no-op registry so the execution flow stays consistent across handlers

Closes #136
