### PR TITLE
Handle BTX completion write failures

### DIFF
--- a/.github/AGENTS.adoc
+++ b/.github/AGENTS.adoc
@@ -174,3 +174,4 @@ Every mutating command is wrapped in a BTX lifecycle:
 * Prefer AsciiDoc for repository docs.
 * Keep architecture notes short and current-state focused.
 * Do not spend doc space on version lists or plugin details.
+* When using given/when/then test comments, write them as `// given`, `// when`, `// then`.

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
@@ -44,12 +44,17 @@ import java.util.logging.Logger;
 ///    bean ensures CDI interceptors fire through the proxy rather than being
 ///    bypassed by a same-bean self-invocation.
 /// 5. On success the BTX row is updated to `COMPLETED` (also `REQUIRES_NEW`).
-/// 6. On any exception the BTX row is updated to `FAILED` (`REQUIRES_NEW`) and
+/// 6. If the completion write itself fails after a successful handler, the service
+///    falls back to marking the BTX row `FAILED` with a dedicated error type so the
+///    row still reaches a terminal state.
+/// 7. On any exception the BTX row is updated to `FAILED` (`REQUIRES_NEW`) and
 ///    the exception is logged.  It does NOT propagate back — the caller fired and forgot.
 @ManagedExecutorDefinition(name = "java:app/concurrent/KeyServerCommandExecutor", virtual = true, maxAsync = -1)
 @Default
 @ApplicationScoped
 public class KeyServerCommandService implements CommandService, Serializable {
+
+    static final String BTX_COMPLETION_WRITE_FAILURE = "BtxCompletionWriteFailure";
 
     private static final Logger LOG = Logger.getLogger(KeyServerCommandService.class.getName());
 
@@ -87,9 +92,12 @@ public class KeyServerCommandService implements CommandService, Serializable {
         try {
             this.btxRepository.recordCompleted(btxId);
         } catch (Exception ex) {
-            LOG.log(Level.WARNING, "Failed to mark BTX {0} COMPLETED after successful command {1}: {2}", new Object[] {
-                btxId, commandType, ex.getMessage()
-            });
+            this.btxRepository.recordFailed(btxId, BTX_COMPLETION_WRITE_FAILURE, ex.getMessage());
+            LOG.log(
+                    Level.WARNING,
+                    "Failed to mark BTX " + btxId + " COMPLETED after successful command " + commandType
+                            + "; BTX marked FAILED instead",
+                    ex);
         }
     }
 

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
@@ -68,19 +68,27 @@ public class KeyServerCommandService implements CommandService, Serializable {
     @Asynchronous(executor = "java:app/concurrent/KeyServerCommandExecutor")
     @Override
     public <T extends KeyServerCommand> void handleCommand(T keyServerCommand, CommandCallerContext callerContext) {
-        long btxId = tsidFactory.generate().toLong();
+        long btxId = this.tsidFactory.generate().toLong();
         String commandType = keyServerCommand.getClass().getSimpleName();
 
-        btxRepository.recordStarted(btxId, commandType, callerContext.anonymizedCallerIp());
-        btxContext.initialize(btxId);
+        this.btxRepository.recordStarted(btxId, commandType, callerContext.anonymizedCallerIp());
+        this.btxContext.initialize(btxId);
 
         try {
-            dispatcher.dispatch(keyServerCommand, callerContext);
-            btxRepository.recordCompleted(btxId);
+            this.dispatcher.dispatch(keyServerCommand, callerContext);
         } catch (Exception ex) {
-            btxRepository.recordFailed(btxId, ex.getClass().getSimpleName(), ex.getMessage());
+            this.btxRepository.recordFailed(btxId, ex.getClass().getSimpleName(), ex.getMessage());
             LOG.log(Level.WARNING, "Command {0} failed for BTX {1}: {2}", new Object[] {
                 commandType, btxId, ex.getMessage()
+            });
+            return;
+        }
+
+        try {
+            this.btxRepository.recordCompleted(btxId);
+        } catch (Exception ex) {
+            LOG.log(Level.WARNING, "Failed to mark BTX {0} COMPLETED after successful command {1}: {2}", new Object[] {
+                btxId, commandType, ex.getMessage()
             });
         }
     }

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
@@ -18,6 +18,7 @@ import jakarta.enterprise.inject.Default;
 import jakarta.inject.Inject;
 import java.io.Serializable;
 import java.util.logging.Level;
+import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 /// Dispatches commands to their handlers inside a dedicated virtual-thread executor.
@@ -92,13 +93,31 @@ public class KeyServerCommandService implements CommandService, Serializable {
         try {
             this.btxRepository.recordCompleted(btxId);
         } catch (Exception ex) {
-            this.btxRepository.recordFailed(btxId, BTX_COMPLETION_WRITE_FAILURE, ex.getMessage());
-            LOG.log(
+            this.logWithThrowable(
                     Level.WARNING,
-                    "Failed to mark BTX " + btxId + " COMPLETED after successful command " + commandType
-                            + "; BTX marked FAILED instead",
-                    ex);
+                    ex,
+                    "Failed to mark BTX {0} COMPLETED after successful command {1}; attempting terminal FAILED fallback",
+                    btxId,
+                    commandType);
+            try {
+                this.btxRepository.recordFailed(btxId, BTX_COMPLETION_WRITE_FAILURE, ex.getMessage());
+            } catch (Exception fallbackEx) {
+                this.logWithThrowable(
+                        Level.WARNING,
+                        fallbackEx,
+                        "Failed to mark BTX {0} FAILED after completion-write failure for command {1}",
+                        btxId,
+                        commandType);
+            }
         }
+    }
+
+    private void logWithThrowable(Level level, Throwable throwable, String message, Object... parameters) {
+        LogRecord logRecord = new LogRecord(level, message);
+        logRecord.setLoggerName(LOG.getName());
+        logRecord.setParameters(parameters);
+        logRecord.setThrown(throwable);
+        LOG.log(logRecord);
     }
 
     // CDI-friendly setters for testing

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 /// 3. The BTX ID is stored in the `@RequestScoped` `BusinessTransactionContext`
 ///    so that any downstream component (audit writer, DAO) can reference it
 ///    without explicit parameter passing.
+///    If either step 2 or 3 fails, the error is logged and the command is not dispatched.
 /// 4. The command handler runs inside a `@Transactional` boundary provided by
 ///    the injected {@link TransactionalCommandDispatcher}.  Using a separate
 ///    bean ensures CDI interceptors fire through the proxy rather than being
@@ -54,9 +55,6 @@ import java.util.logging.Logger;
 @Default
 @ApplicationScoped
 public class KeyServerCommandService implements CommandService, Serializable {
-
-    static final String BTX_COMPLETION_WRITE_FAILURE = "BtxCompletionWriteFailure";
-
     private static final Logger LOG = Logger.getLogger(KeyServerCommandService.class.getName());
 
     @Inject
@@ -77,38 +75,67 @@ public class KeyServerCommandService implements CommandService, Serializable {
         long btxId = this.tsidFactory.generate().toLong();
         String commandType = keyServerCommand.getClass().getSimpleName();
 
-        this.btxRepository.recordStarted(btxId, commandType, callerContext.anonymizedCallerIp());
-        this.btxContext.initialize(btxId);
+        try {
+            this.btxRepository.recordStarted(btxId, commandType, callerContext.anonymizedCallerIp());
+            this.btxContext.initialize(btxId);
+        } catch (Exception ex) {
+            this.logWithThrowable(
+                    Level.WARNING,
+                    ex,
+                    "Failed to initialize BTX {0} for command {1}; command not dispatched",
+                    btxId,
+                    commandType);
+            return;
+        }
 
         try {
             this.dispatcher.dispatch(keyServerCommand, callerContext);
         } catch (Exception ex) {
-            this.btxRepository.recordFailed(btxId, ex.getClass().getSimpleName(), ex.getMessage());
-            LOG.log(Level.WARNING, "Command {0} failed for BTX {1}: {2}", new Object[] {
-                commandType, btxId, ex.getMessage()
-            });
+            this.recordFailedSafely(
+                    btxId,
+                    commandType,
+                    ex.getClass().getSimpleName(),
+                    ex.getMessage(),
+                    ex,
+                    "Command {0} failed for BTX {1}",
+                    commandType,
+                    btxId);
             return;
         }
 
         try {
             this.btxRepository.recordCompleted(btxId);
         } catch (Exception ex) {
-            this.logWithThrowable(
-                    Level.WARNING,
+            this.recordFailedSafely(
+                    btxId,
+                    commandType,
+                    ex.getClass().getSimpleName(),
+                    "BTX completion write failure: " + ex.getMessage(),
                     ex,
                     "Failed to mark BTX {0} COMPLETED after successful command {1}; attempting terminal FAILED fallback",
                     btxId,
                     commandType);
-            try {
-                this.btxRepository.recordFailed(btxId, BTX_COMPLETION_WRITE_FAILURE, ex.getMessage());
-            } catch (Exception fallbackEx) {
-                this.logWithThrowable(
-                        Level.WARNING,
-                        fallbackEx,
-                        "Failed to mark BTX {0} FAILED after completion-write failure for command {1}",
-                        btxId,
-                        commandType);
-            }
+        }
+    }
+
+    private void recordFailedSafely(
+            long btxId,
+            String commandType,
+            String errorType,
+            String errorMessage,
+            Throwable throwable,
+            String logMessage,
+            Object... logParameters) {
+        this.logWithThrowable(Level.WARNING, throwable, logMessage, logParameters);
+        try {
+            this.btxRepository.recordFailed(btxId, errorType, errorMessage);
+        } catch (Exception fallbackEx) {
+            this.logWithThrowable(
+                    Level.WARNING,
+                    fallbackEx,
+                    "Failed to persist BTX {0} FAILED state for command {1}",
+                    btxId,
+                    commandType);
         }
     }
 

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandService.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import org.jspecify.annotations.Nullable;
 
 /// Dispatches commands to their handlers inside a dedicated virtual-thread executor.
 ///
@@ -47,8 +48,8 @@ import java.util.logging.Logger;
 ///    bypassed by a same-bean self-invocation.
 /// 5. On success the BTX row is updated to `COMPLETED` (also `REQUIRES_NEW`).
 /// 6. If the completion write itself fails after a successful handler, the service
-///    falls back to marking the BTX row `FAILED` with a dedicated error type so the
-///    row still reaches a terminal state.
+///    falls back to marking the BTX row `FAILED` with the original exception type
+///    and a prefixed audit message so the row still reaches a terminal state.
 /// 7. On any exception the BTX row is updated to `FAILED` (`REQUIRES_NEW`) and
 ///    the exception is logged.  It does NOT propagate back — the caller fired and forgot.
 @ManagedExecutorDefinition(name = "java:app/concurrent/KeyServerCommandExecutor", virtual = true, maxAsync = -1)
@@ -74,55 +75,65 @@ public class KeyServerCommandService implements CommandService, Serializable {
     public <T extends KeyServerCommand> void handleCommand(T keyServerCommand, CommandCallerContext callerContext) {
         long btxId = this.tsidFactory.generate().toLong();
         String commandType = keyServerCommand.getClass().getSimpleName();
+        boolean startedRecorded = false;
+        boolean dispatchedSuccessfully = false;
 
         try {
             this.btxRepository.recordStarted(btxId, commandType, callerContext.anonymizedCallerIp());
+            startedRecorded = true;
             this.btxContext.initialize(btxId);
-        } catch (Exception ex) {
-            this.logWithThrowable(
-                    Level.WARNING,
-                    ex,
-                    "Failed to initialize BTX {0} for command {1}; command not dispatched",
-                    btxId,
-                    commandType);
-            return;
-        }
-
-        try {
             this.dispatcher.dispatch(keyServerCommand, callerContext);
+            dispatchedSuccessfully = true;
         } catch (Exception ex) {
+            if (!startedRecorded) {
+                this.logWithThrowable(
+                        Level.WARNING,
+                        ex,
+                        "Failed to record STARTED BTX {0} for command {1}; command not dispatched",
+                        btxId,
+                        commandType);
+                return;
+            }
             this.recordFailedSafely(
                     btxId,
                     commandType,
                     ex.getClass().getSimpleName(),
                     ex.getMessage(),
                     ex,
-                    "Command {0} failed for BTX {1}",
+                    "Failed to prepare or dispatch command {0} for BTX {1}",
                     commandType,
                     btxId);
-            return;
+        } finally {
+            if (dispatchedSuccessfully) {
+                try {
+                    this.btxRepository.recordCompleted(btxId);
+                } catch (Exception ex) {
+                    this.recordFailedSafely(
+                            btxId,
+                            commandType,
+                            ex.getClass().getSimpleName(),
+                            this.toCompletionWriteFailureMessage(ex.getMessage()),
+                            ex,
+                            "Failed to mark BTX {0} COMPLETED after successful command {1}; attempting terminal FAILED fallback",
+                            btxId,
+                            commandType);
+                }
+            }
         }
+    }
 
-        try {
-            this.btxRepository.recordCompleted(btxId);
-        } catch (Exception ex) {
-            this.recordFailedSafely(
-                    btxId,
-                    commandType,
-                    ex.getClass().getSimpleName(),
-                    "BTX completion write failure: " + ex.getMessage(),
-                    ex,
-                    "Failed to mark BTX {0} COMPLETED after successful command {1}; attempting terminal FAILED fallback",
-                    btxId,
-                    commandType);
+    private String toCompletionWriteFailureMessage(@Nullable String errorMessage) {
+        if (errorMessage == null) {
+            return "BTX completion write failure";
         }
+        return "BTX completion write failure: " + errorMessage;
     }
 
     private void recordFailedSafely(
             long btxId,
             String commandType,
             String errorType,
-            String errorMessage,
+            @Nullable String errorMessage,
             Throwable throwable,
             String logMessage,
             Object... logParameters) {

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -131,6 +131,40 @@ class KeyServerCommandServiceTest {
     }
 
     @Test
+    void records_failed_when_context_initialize_throws_after_record_started() {
+        // given
+        // Once the STARTED row exists, a later context-initialization failure must still end in a terminal BTX state.
+        var trackingRepo = new TrackingBusinessTransactionRepository();
+        var handler = new SuccessCommandHandler();
+        var btxContext = new BusinessTransactionContext();
+        btxContext.initialize(123L);
+        KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.of(handler), btxContext);
+
+        // when
+        service.handleCommand(new TestCommand(), CommandCallerContext.empty());
+
+        // then
+        assertThat(trackingRepo.startedCount)
+                .as("the BTX row must already exist before the second initialize() call fails")
+                .isEqualTo(1);
+        assertThat(handler.executeCount)
+                .as("dispatch must not continue after the request-scoped BTX context rejects reinitialization")
+                .isZero();
+        assertThat(trackingRepo.failedCount)
+                .as("an initialization failure after recordStarted() must still move the BTX to FAILED")
+                .isEqualTo(1);
+        assertThat(trackingRepo.completedCount)
+                .as("a command that never dispatched must not reach COMPLETED")
+                .isZero();
+        assertThat(trackingRepo.lastErrorType)
+                .as("the persisted BTX failure should keep the concrete initialization exception type")
+                .isEqualTo("IllegalStateException");
+        assertThat(trackingRepo.lastErrorMessage)
+                .as("the BTX audit message should preserve why the request-scoped context rejected initialization")
+                .isEqualTo("BusinessTransactionContext already initialized");
+    }
+
+    @Test
     void records_completed_after_successful_dispatch() {
         // given
         // A successful handler must drive the normal BTX happy path all the way to recordCompleted().

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -127,9 +127,10 @@ class KeyServerCommandServiceTest {
     }
 
     @Test
-    void ignores_record_completed_failure_after_successful_dispatch() {
+    void records_failed_when_record_completed_throws_after_successful_dispatch() {
         // given
-        // Issue #134: a successful handler plus failing recordCompleted() must not reclassify the BTX as FAILED.
+        // Issue #134: a successful handler plus failing recordCompleted() must still end in a terminal FAILED BTX
+        // state.
         var trackingRepo = new ThrowingOnRecordCompletedRepository();
         var handler = new SuccessCommandHandler();
         KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.of(handler));
@@ -159,6 +160,32 @@ class KeyServerCommandServiceTest {
                 .isEqualTo(KeyServerCommandService.BTX_COMPLETION_WRITE_FAILURE);
     }
 
+    @Test
+    void swallows_record_failed_when_completion_and_fallback_writes_both_throw() {
+        // given
+        // Even if both terminal-state writes fail, the async service must log and swallow rather than propagate.
+        var trackingRepo = new ThrowingOnCompletionAndFailureRepository();
+        var handler = new SuccessCommandHandler();
+        KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.of(handler));
+
+        // when
+        service.handleCommand(new TestCommand(), CommandCallerContext.empty());
+
+        // then
+        assertThat(handler.executeCount)
+                .as("the command handler must already have completed before the BTX completion write fails")
+                .isEqualTo(1);
+        assertThat(trackingRepo.recordCompletedAttemptCount)
+                .as("the service must attempt the normal BTX completion write first")
+                .isEqualTo(1);
+        assertThat(trackingRepo.recordFailedAttemptCount)
+                .as("after the completion write fails, the service must attempt the terminal FAILED fallback")
+                .isEqualTo(1);
+        assertThat(trackingRepo.failedCount)
+                .as("the fallback write never persisted because the repository simulated a second failure")
+                .isZero();
+    }
+
     private static final class SuccessCommandHandler implements CommandHandler<TestCommand> {
         int executeCount;
 
@@ -177,6 +204,7 @@ class KeyServerCommandServiceTest {
     private static class TrackingBusinessTransactionRepository implements BusinessTransactionRepository {
         int startedCount;
         int recordCompletedAttemptCount;
+        int recordFailedAttemptCount;
         int completedCount;
         int failedCount;
 
@@ -201,17 +229,28 @@ class KeyServerCommandServiceTest {
 
         @Override
         public void recordFailed(long btxId, String errorType, @Nullable String errorMessage) {
+            this.recordFailedAttemptCount++;
+            this.beforeMarkingFailed(btxId, errorType, errorMessage);
             this.failedCount++;
             this.lastErrorType = errorType;
         }
 
         protected void beforeMarkingCompleted(long btxId) {}
+
+        protected void beforeMarkingFailed(long btxId, String errorType, @Nullable String errorMessage) {}
     }
 
-    private static final class ThrowingOnRecordCompletedRepository extends TrackingBusinessTransactionRepository {
+    private static class ThrowingOnRecordCompletedRepository extends TrackingBusinessTransactionRepository {
         @Override
         protected void beforeMarkingCompleted(long btxId) {
             throw new IllegalStateException("simulated completion write failure");
+        }
+    }
+
+    private static final class ThrowingOnCompletionAndFailureRepository extends ThrowingOnRecordCompletedRepository {
+        @Override
+        protected void beforeMarkingFailed(long btxId, String errorType, @Nullable String errorMessage) {
+            throw new IllegalStateException("simulated fallback write failure");
         }
     }
 }

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -101,8 +101,7 @@ class KeyServerCommandServiceTest {
     void ignores_record_completed_failure_after_successful_dispatch() {
         // given
         // Issue #134: a successful handler plus failing recordCompleted() must not reclassify the BTX as FAILED.
-        var trackingRepo = new TrackingBusinessTransactionRepository();
-        trackingRepo.throwOnRecordCompleted = true;
+        var trackingRepo = new ThrowingOnRecordCompletedRepository();
         var handler = new SuccessCommandHandler();
         KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.of(handler));
 
@@ -142,12 +141,11 @@ class KeyServerCommandServiceTest {
         }
     }
 
-    private static final class TrackingBusinessTransactionRepository implements BusinessTransactionRepository {
+    private static class TrackingBusinessTransactionRepository implements BusinessTransactionRepository {
         int startedCount;
         int recordCompletedAttemptCount;
         int completedCount;
         int failedCount;
-        boolean throwOnRecordCompleted;
 
         @Nullable
         String lastCallerIp;
@@ -164,16 +162,20 @@ class KeyServerCommandServiceTest {
         @Override
         public void recordCompleted(long btxId) {
             this.recordCompletedAttemptCount++;
-            if (this.throwOnRecordCompleted) {
-                throw new IllegalStateException("simulated completion write failure");
-            }
-            this.completedCount++;
         }
 
         @Override
         public void recordFailed(long btxId, String errorType, @Nullable String errorMessage) {
             failedCount++;
             lastErrorType = errorType;
+        }
+    }
+
+    private static final class ThrowingOnRecordCompletedRepository extends TrackingBusinessTransactionRepository {
+        @Override
+        public void recordCompleted(long btxId) {
+            super.recordCompleted(btxId);
+            throw new IllegalStateException("simulated completion write failure");
         }
     }
 }

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -39,23 +39,34 @@ class KeyServerCommandServiceTest {
     @Test
     void records_failed_on_unknown_command_type() {
         // given
+        // No handler is registered, so the dispatcher must fail and the BTX must end up FAILED.
         var noopCommand = new KeyServerCommand() {};
         var trackingRepo = new TrackingBusinessTransactionRepository();
         KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.empty());
 
         // when
+        // @Asynchronous is not intercepted in unit tests, so the service runs synchronously here.
         service.handleCommand(noopCommand, CommandCallerContext.empty());
 
         // then
-        assertThat(trackingRepo.startedCount).isEqualTo(1);
-        assertThat(trackingRepo.failedCount).isEqualTo(1);
-        assertThat(trackingRepo.completedCount).isZero();
-        assertThat(trackingRepo.lastErrorType).isEqualTo("UnsupportedOperationException");
+        assertThat(trackingRepo.startedCount)
+                .as("the BTX row must be opened before dispatch so failed commands are still auditable")
+                .isEqualTo(1);
+        assertThat(trackingRepo.failedCount)
+                .as("unknown commands must mark the BTX as FAILED instead of leaving it in STARTED")
+                .isEqualTo(1);
+        assertThat(trackingRepo.completedCount)
+                .as("a failed dispatch must never mark the BTX as COMPLETED")
+                .isZero();
+        assertThat(trackingRepo.lastErrorType)
+                .as("the BTX failure audit must retain the concrete exception type for diagnosis")
+                .isEqualTo("UnsupportedOperationException");
     }
 
     @Test
     void forwards_callerIp_from_context_to_recordStarted() {
         // given
+        // The anonymized caller IP is part of the BTX audit trail and must survive dispatch unchanged.
         var noopCommand = new KeyServerCommand() {};
         var trackingRepo = new TrackingBusinessTransactionRepository();
         KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.empty());
@@ -64,12 +75,15 @@ class KeyServerCommandServiceTest {
         service.handleCommand(noopCommand, CommandCallerContext.of("192.168.1.0"));
 
         // then
-        assertThat(trackingRepo.lastCallerIp).isEqualTo("192.168.1.0");
+        assertThat(trackingRepo.lastCallerIp)
+                .as("the anonymized IP must reach recordStarted unchanged so the BTX audit row keeps caller context")
+                .isEqualTo("192.168.1.0");
     }
 
     @Test
     void records_null_callerIp_when_context_is_empty() {
         // given
+        // Internally triggered commands may not have caller metadata, and that absence must persist cleanly.
         var noopCommand = new KeyServerCommand() {};
         var trackingRepo = new TrackingBusinessTransactionRepository();
         KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.empty());
@@ -78,12 +92,15 @@ class KeyServerCommandServiceTest {
         service.handleCommand(noopCommand, CommandCallerContext.empty());
 
         // then
-        assertThat(trackingRepo.lastCallerIp).isNull();
+        assertThat(trackingRepo.lastCallerIp)
+                .as("empty caller context must not invent an IP address in the BTX audit row")
+                .isNull();
     }
 
     @Test
     void ignores_record_completed_failure_after_successful_dispatch() {
         // given
+        // Issue #134: a successful handler plus failing recordCompleted() must not reclassify the BTX as FAILED.
         var trackingRepo = new TrackingBusinessTransactionRepository();
         trackingRepo.throwOnRecordCompleted = true;
         var handler = new SuccessCommandHandler();
@@ -93,10 +110,21 @@ class KeyServerCommandServiceTest {
         service.handleCommand(new TestCommand(), CommandCallerContext.empty());
 
         // then
-        assertThat(handler.executeCount).isEqualTo(1);
-        assertThat(trackingRepo.startedCount).isEqualTo(1);
-        assertThat(trackingRepo.completedCount).isZero();
-        assertThat(trackingRepo.failedCount).isZero();
+        assertThat(handler.executeCount)
+                .as("the handler must still execute successfully before the completion write fails")
+                .isEqualTo(1);
+        assertThat(trackingRepo.startedCount)
+                .as("the BTX row must still be opened for a successful command")
+                .isEqualTo(1);
+        assertThat(trackingRepo.recordCompletedAttemptCount)
+                .as("the regression test must prove the service reached recordCompleted() before the simulated failure")
+                .isEqualTo(1);
+        assertThat(trackingRepo.completedCount)
+                .as("the repository never recorded COMPLETED because recordCompleted() threw")
+                .isZero();
+        assertThat(trackingRepo.failedCount)
+                .as("a completion-write failure after a successful handler must not mark the BTX as FAILED")
+                .isZero();
     }
 
     private static final class SuccessCommandHandler implements CommandHandler<TestCommand> {
@@ -116,6 +144,7 @@ class KeyServerCommandServiceTest {
 
     private static final class TrackingBusinessTransactionRepository implements BusinessTransactionRepository {
         int startedCount;
+        int recordCompletedAttemptCount;
         int completedCount;
         int failedCount;
         boolean throwOnRecordCompleted;
@@ -134,6 +163,7 @@ class KeyServerCommandServiceTest {
 
         @Override
         public void recordCompleted(long btxId) {
+            this.recordCompletedAttemptCount++;
             if (this.throwOnRecordCompleted) {
                 throw new IllegalStateException("simulated completion write failure");
             }

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
+import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommandResponse;
 import io.github.bmarwell.keyserver.application.core.cmdhandler.CommandHandler;
 import io.github.bmarwell.keyserver.application.core.concurrent.BusinessTransactionContext;
 import io.github.bmarwell.keyserver.application.port.repository.BusinessTransactionRepository;
@@ -18,6 +19,8 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 class KeyServerCommandServiceTest {
+
+    private record TestCommand() implements KeyServerCommand {}
 
     private static KeyServerCommandService buildService(
             TrackingBusinessTransactionRepository trackingRepo,
@@ -35,15 +38,15 @@ class KeyServerCommandServiceTest {
 
     @Test
     void records_failed_on_unknown_command_type() {
-        // given:
+        // given
         var noopCommand = new KeyServerCommand() {};
         var trackingRepo = new TrackingBusinessTransactionRepository();
         KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.empty());
 
-        // when: @Asynchronous is not intercepted in unit tests — runs synchronously
+        // when
         service.handleCommand(noopCommand, CommandCallerContext.empty());
 
-        // then: BTX was started and then recorded as failed with the exception type
+        // then
         assertThat(trackingRepo.startedCount).isEqualTo(1);
         assertThat(trackingRepo.failedCount).isEqualTo(1);
         assertThat(trackingRepo.completedCount).isZero();
@@ -52,36 +55,70 @@ class KeyServerCommandServiceTest {
 
     @Test
     void forwards_callerIp_from_context_to_recordStarted() {
-        // given:
+        // given
         var noopCommand = new KeyServerCommand() {};
         var trackingRepo = new TrackingBusinessTransactionRepository();
         KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.empty());
 
-        // when:
+        // when
         service.handleCommand(noopCommand, CommandCallerContext.of("192.168.1.0"));
 
-        // then: the anonymized IP must reach recordStarted unchanged
+        // then
         assertThat(trackingRepo.lastCallerIp).isEqualTo("192.168.1.0");
     }
 
     @Test
     void records_null_callerIp_when_context_is_empty() {
-        // given:
+        // given
         var noopCommand = new KeyServerCommand() {};
         var trackingRepo = new TrackingBusinessTransactionRepository();
         KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.empty());
 
-        // when:
+        // when
         service.handleCommand(noopCommand, CommandCallerContext.empty());
 
-        // then:
+        // then
         assertThat(trackingRepo.lastCallerIp).isNull();
+    }
+
+    @Test
+    void ignores_record_completed_failure_after_successful_dispatch() {
+        // given
+        var trackingRepo = new TrackingBusinessTransactionRepository();
+        trackingRepo.throwOnRecordCompleted = true;
+        var handler = new SuccessCommandHandler();
+        KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.of(handler));
+
+        // when
+        service.handleCommand(new TestCommand(), CommandCallerContext.empty());
+
+        // then
+        assertThat(handler.executeCount).isEqualTo(1);
+        assertThat(trackingRepo.startedCount).isEqualTo(1);
+        assertThat(trackingRepo.completedCount).isZero();
+        assertThat(trackingRepo.failedCount).isZero();
+    }
+
+    private static final class SuccessCommandHandler implements CommandHandler<TestCommand> {
+        int executeCount;
+
+        @Override
+        public <C extends KeyServerCommand> boolean canHandle(C command) {
+            return command instanceof TestCommand;
+        }
+
+        @Override
+        public KeyServerCommandResponse execute(KeyServerCommand command, CommandCallerContext callerContext) {
+            this.executeCount++;
+            return KeyServerCommandResponse.success();
+        }
     }
 
     private static final class TrackingBusinessTransactionRepository implements BusinessTransactionRepository {
         int startedCount;
         int completedCount;
         int failedCount;
+        boolean throwOnRecordCompleted;
 
         @Nullable
         String lastCallerIp;
@@ -97,7 +134,10 @@ class KeyServerCommandServiceTest {
 
         @Override
         public void recordCompleted(long btxId) {
-            completedCount++;
+            if (this.throwOnRecordCompleted) {
+                throw new IllegalStateException("simulated completion write failure");
+            }
+            this.completedCount++;
         }
 
         @Override

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -25,12 +25,19 @@ class KeyServerCommandServiceTest {
     private static KeyServerCommandService buildService(
             TrackingBusinessTransactionRepository trackingRepo,
             SimpleInstance<CommandHandler<? extends KeyServerCommand>> handlers) {
+        return buildService(trackingRepo, handlers, new BusinessTransactionContext());
+    }
+
+    private static KeyServerCommandService buildService(
+            TrackingBusinessTransactionRepository trackingRepo,
+            SimpleInstance<CommandHandler<? extends KeyServerCommand>> handlers,
+            BusinessTransactionContext btxContext) {
         var dispatcher = new TransactionalCommandDispatcher();
         dispatcher.setCommandHandlers(handlers);
         KeyServerCommandService service = new KeyServerCommandService();
         service.setDispatcher(dispatcher);
         service.setBtxRepository(trackingRepo);
-        service.setBtxContext(new BusinessTransactionContext());
+        service.setBtxContext(btxContext);
         service.setTsidFactory(
                 TSID.Factory.builder().withNodeBits(10).withNode(0).build());
         return service;
@@ -98,6 +105,32 @@ class KeyServerCommandServiceTest {
     }
 
     @Test
+    void swallows_record_started_failure_before_dispatch() {
+        // given
+        // Fire-and-forget dispatch must not propagate when the STARTED write itself fails.
+        var trackingRepo = new ThrowingOnRecordStartedRepository();
+        var handler = new SuccessCommandHandler();
+        KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.of(handler));
+
+        // when
+        service.handleCommand(new TestCommand(), CommandCallerContext.empty());
+
+        // then
+        assertThat(trackingRepo.recordStartedAttemptCount)
+                .as("the service must attempt to create the STARTED BTX row before any handler dispatch")
+                .isEqualTo(1);
+        assertThat(handler.executeCount)
+                .as("dispatch must not continue when the STARTED BTX write failed")
+                .isZero();
+        assertThat(trackingRepo.failedCount)
+                .as("without a durable STARTED row, the service cannot persist a terminal BTX failure")
+                .isZero();
+        assertThat(trackingRepo.completedCount)
+                .as("a command that never dispatched must not reach COMPLETED")
+                .isZero();
+    }
+
+    @Test
     void records_completed_after_successful_dispatch() {
         // given
         // A successful handler must drive the normal BTX happy path all the way to recordCompleted().
@@ -156,8 +189,11 @@ class KeyServerCommandServiceTest {
                         "a completion-write failure after a successful handler must still move the BTX to a terminal FAILED state")
                 .isEqualTo(1);
         assertThat(trackingRepo.lastErrorType)
-                .as("completion-write failures should use a dedicated BTX error type for diagnosis")
-                .isEqualTo(KeyServerCommandService.BTX_COMPLETION_WRITE_FAILURE);
+                .as("completion-write failures should preserve the concrete persistence exception type for diagnosis")
+                .isEqualTo("IllegalStateException");
+        assertThat(trackingRepo.lastErrorMessage)
+                .as("completion-write failures should still be clearly marked in the stored audit message")
+                .isEqualTo("BTX completion write failure: simulated completion write failure");
     }
 
     @Test
@@ -203,6 +239,7 @@ class KeyServerCommandServiceTest {
 
     private static class TrackingBusinessTransactionRepository implements BusinessTransactionRepository {
         int startedCount;
+        int recordStartedAttemptCount;
         int recordCompletedAttemptCount;
         int recordFailedAttemptCount;
         int completedCount;
@@ -214,8 +251,13 @@ class KeyServerCommandServiceTest {
         @Nullable
         String lastErrorType;
 
+        @Nullable
+        String lastErrorMessage;
+
         @Override
         public void recordStarted(long btxId, String commandType, @Nullable String callerIp) {
+            this.recordStartedAttemptCount++;
+            this.beforeMarkingStarted(btxId, commandType, callerIp);
             this.startedCount++;
             this.lastCallerIp = callerIp;
         }
@@ -233,11 +275,21 @@ class KeyServerCommandServiceTest {
             this.beforeMarkingFailed(btxId, errorType, errorMessage);
             this.failedCount++;
             this.lastErrorType = errorType;
+            this.lastErrorMessage = errorMessage;
         }
+
+        protected void beforeMarkingStarted(long btxId, String commandType, @Nullable String callerIp) {}
 
         protected void beforeMarkingCompleted(long btxId) {}
 
         protected void beforeMarkingFailed(long btxId, String errorType, @Nullable String errorMessage) {}
+    }
+
+    private static final class ThrowingOnRecordStartedRepository extends TrackingBusinessTransactionRepository {
+        @Override
+        protected void beforeMarkingStarted(long btxId, String commandType, @Nullable String callerIp) {
+            throw new IllegalStateException("simulated started write failure");
+        }
     }
 
     private static class ThrowingOnRecordCompletedRepository extends TrackingBusinessTransactionRepository {

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -98,6 +98,35 @@ class KeyServerCommandServiceTest {
     }
 
     @Test
+    void records_completed_after_successful_dispatch() {
+        // given
+        // A successful handler must drive the normal BTX happy path all the way to recordCompleted().
+        var trackingRepo = new TrackingBusinessTransactionRepository();
+        var handler = new SuccessCommandHandler();
+        KeyServerCommandService service = buildService(trackingRepo, SimpleInstance.of(handler));
+
+        // when
+        service.handleCommand(new TestCommand(), CommandCallerContext.empty());
+
+        // then
+        assertThat(handler.executeCount)
+                .as("the happy path must still execute the matched command handler exactly once")
+                .isEqualTo(1);
+        assertThat(trackingRepo.startedCount)
+                .as("successful commands must still open a BTX row before dispatch")
+                .isEqualTo(1);
+        assertThat(trackingRepo.recordCompletedAttemptCount)
+                .as("the success path must reach the shared recordCompleted() implementation")
+                .isEqualTo(1);
+        assertThat(trackingRepo.completedCount)
+                .as("successful commands must mark the BTX as COMPLETED")
+                .isEqualTo(1);
+        assertThat(trackingRepo.failedCount)
+                .as("the happy path must not record a BTX failure")
+                .isZero();
+    }
+
+    @Test
     void ignores_record_completed_failure_after_successful_dispatch() {
         // given
         // Issue #134: a successful handler plus failing recordCompleted() must not reclassify the BTX as FAILED.
@@ -162,6 +191,8 @@ class KeyServerCommandServiceTest {
         @Override
         public void recordCompleted(long btxId) {
             this.recordCompletedAttemptCount++;
+            this.beforeMarkingCompleted(btxId);
+            this.completedCount++;
         }
 
         @Override
@@ -169,12 +200,13 @@ class KeyServerCommandServiceTest {
             failedCount++;
             lastErrorType = errorType;
         }
+
+        protected void beforeMarkingCompleted(long btxId) {}
     }
 
     private static final class ThrowingOnRecordCompletedRepository extends TrackingBusinessTransactionRepository {
         @Override
-        public void recordCompleted(long btxId) {
-            super.recordCompleted(btxId);
+        protected void beforeMarkingCompleted(long btxId) {
             throw new IllegalStateException("simulated completion write failure");
         }
     }

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -148,11 +148,15 @@ class KeyServerCommandServiceTest {
                 .as("the regression test must prove the service reached recordCompleted() before the simulated failure")
                 .isEqualTo(1);
         assertThat(trackingRepo.completedCount)
-                .as("the repository never recorded COMPLETED because recordCompleted() threw")
+                .as("the repository must not report COMPLETED when the completion write failed")
                 .isZero();
         assertThat(trackingRepo.failedCount)
-                .as("a completion-write failure after a successful handler must not mark the BTX as FAILED")
-                .isZero();
+                .as(
+                        "a completion-write failure after a successful handler must still move the BTX to a terminal FAILED state")
+                .isEqualTo(1);
+        assertThat(trackingRepo.lastErrorType)
+                .as("completion-write failures should use a dedicated BTX error type for diagnosis")
+                .isEqualTo(KeyServerCommandService.BTX_COMPLETION_WRITE_FAILURE);
     }
 
     private static final class SuccessCommandHandler implements CommandHandler<TestCommand> {
@@ -184,8 +188,8 @@ class KeyServerCommandServiceTest {
 
         @Override
         public void recordStarted(long btxId, String commandType, @Nullable String callerIp) {
-            startedCount++;
-            lastCallerIp = callerIp;
+            this.startedCount++;
+            this.lastCallerIp = callerIp;
         }
 
         @Override
@@ -197,8 +201,8 @@ class KeyServerCommandServiceTest {
 
         @Override
         public void recordFailed(long btxId, String errorType, @Nullable String errorMessage) {
-            failedCount++;
-            lastErrorType = errorType;
+            this.failedCount++;
+            this.lastErrorType = errorType;
         }
 
         protected void beforeMarkingCompleted(long btxId) {}


### PR DESCRIPTION
## Summary
- keep successful command dispatch separate from BTX completion persistence
- if `recordCompleted()` fails, log the exception, attempt a terminal FAILED fallback, and swallow any fallback-write failure after logging it
- add focused regression tests for the shared BTX completion path using `// given`, `// when`, `// then` comments