### PR TITLE
fix: populate business_transactions.fingerprint

### DIFF
--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
@@ -11,7 +11,9 @@ import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommand;
 import io.github.bmarwell.keyserver.application.api.commands.KeyServerCommandResponse;
 import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.CommandVerificationRegistry;
 import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.KeySubmissionVerifier;
+import io.github.bmarwell.keyserver.application.core.concurrent.BusinessTransactionContext;
 import io.github.bmarwell.keyserver.application.port.notification.VerificationNotificationPort;
+import io.github.bmarwell.keyserver.application.port.repository.BusinessTransactionRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationRequest;
 import jakarta.enterprise.context.RequestScoped;
@@ -75,6 +77,12 @@ public class AddKeyToVerificationQueueCommandHandler
     VerificationNotificationPort notificationPort;
 
     @Inject
+    BusinessTransactionRepository btxRepository;
+
+    @Inject
+    BusinessTransactionContext btxContext;
+
+    @Inject
     @ConfigProperty(name = MAX_KEY_BYTES_CONFIG_KEY, defaultValue = "" + DEFAULT_MAX_KEY_BYTES)
     int maxKeyBytes;
 
@@ -101,6 +109,12 @@ public class AddKeyToVerificationQueueCommandHandler
             AddKeyToVerificationQueueCommand command,
             KeySubmissionVerifier.VerifiedKeySubmission verification,
             CommandCallerContext callerContext) {
+        // All identities share the same primary key fingerprint; record it once.
+        if (!verification.verifiedIdentities().isEmpty()) {
+            this.btxRepository.recordFingerprint(
+                    this.btxContext.getBtxId(),
+                    verification.verifiedIdentities().getFirst().fingerprint());
+        }
         this.enqueueVerificationRequests(verification);
 
         return KeyServerCommandResponse.success();
@@ -137,6 +151,14 @@ public class AddKeyToVerificationQueueCommandHandler
 
     public void setNotificationPort(VerificationNotificationPort notificationPort) {
         this.notificationPort = notificationPort;
+    }
+
+    public void setBtxRepository(BusinessTransactionRepository btxRepository) {
+        this.btxRepository = btxRepository;
+    }
+
+    public void setBtxContext(BusinessTransactionContext btxContext) {
+        this.btxContext = btxContext;
     }
 
     void setKeySubmissionVerifier(

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandler.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import java.net.URI;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /// Handles the {@link AddKeyToVerificationQueueCommand}.
@@ -109,11 +110,15 @@ public class AddKeyToVerificationQueueCommandHandler
             AddKeyToVerificationQueueCommand command,
             KeySubmissionVerifier.VerifiedKeySubmission verification,
             CommandCallerContext callerContext) {
-        // All identities share the same primary key fingerprint; record it once.
-        if (!verification.verifiedIdentities().isEmpty()) {
-            this.btxRepository.recordFingerprint(
-                    this.btxContext.getBtxId(),
-                    verification.verifiedIdentities().getFirst().fingerprint());
+        // Record the fingerprint on the BTX row when all identities share the same primary key.
+        // If identities from multiple distinct keys were submitted we skip fingerprint recording;
+        // picking the first arbitrarily would make the BTX row misleading.
+        List<String> distinctFingerprints = verification.verifiedIdentities().stream()
+                .map(KeySubmissionVerifier.VerifiedKeyIdentity::fingerprint)
+                .distinct()
+                .toList();
+        if (distinctFingerprints.size() == 1) {
+            this.btxRepository.recordFingerprint(this.btxContext.getBtxId(), distinctFingerprints.getFirst());
         }
         this.enqueueVerificationRequests(verification);
 

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
@@ -85,12 +85,15 @@ public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<Ver
                         // injection if a caller passes an extremely long or control-char-bearing string.
                         "Verification token not found or already consumed"));
 
+        // Record the fingerprint as soon as we know it, before any further checks.
+        // This ensures the BTX audit row is populated even when the token is expired.
+        this.btxRepository.recordFingerprint(this.btxContext.getBtxId(), entry.fingerprint());
+
         if (entry.expiresAt().isBefore(OffsetDateTime.now())) {
             throw new TokenExpiredException("Verification token has expired for fingerprint " + entry.fingerprint());
         }
 
         this.verificationQueueRepository.markVerified(tokenId);
-        this.btxRepository.recordFingerprint(this.btxContext.getBtxId(), entry.fingerprint());
         this.keyRepository.publishVerifiedUid(
                 entry.fingerprint(), entry.uidRaw(), entry.uidEmail(), entry.armoredKey());
 

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandler.java
@@ -14,6 +14,8 @@ import io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException;
 import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.CommandVerificationRegistry;
 import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.NoCommandVerification;
 import io.github.bmarwell.keyserver.application.core.cmdhandler.verification.NoOpCommandVerificationRegistry;
+import io.github.bmarwell.keyserver.application.core.concurrent.BusinessTransactionContext;
+import io.github.bmarwell.keyserver.application.port.repository.BusinessTransactionRepository;
 import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationEntry;
@@ -53,6 +55,12 @@ public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<Ver
     @Inject
     KeyRepository keyRepository;
 
+    @Inject
+    BusinessTransactionRepository btxRepository;
+
+    @Inject
+    BusinessTransactionContext btxContext;
+
     @Override
     public <C extends KeyServerCommand> boolean canHandle(C command) {
         return command instanceof VerifyUidCommand;
@@ -82,6 +90,7 @@ public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<Ver
         }
 
         this.verificationQueueRepository.markVerified(tokenId);
+        this.btxRepository.recordFingerprint(this.btxContext.getBtxId(), entry.fingerprint());
         this.keyRepository.publishVerifiedUid(
                 entry.fingerprint(), entry.uidRaw(), entry.uidEmail(), entry.armoredKey());
 
@@ -105,5 +114,13 @@ public class VerifyUidCommandHandler extends AbstractKeyServerCommandHandler<Ver
 
     public void setKeyRepository(KeyRepository keyRepository) {
         this.keyRepository = keyRepository;
+    }
+
+    public void setBtxRepository(BusinessTransactionRepository btxRepository) {
+        this.btxRepository = btxRepository;
+    }
+
+    public void setBtxContext(BusinessTransactionContext btxContext) {
+        this.btxContext = btxContext;
     }
 }

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/KeyServerCommandServiceTest.java
@@ -319,6 +319,11 @@ class KeyServerCommandServiceTest {
         }
 
         @Override
+        public void recordFingerprint(long btxId, String fingerprint) {
+            // no-op tracking; fingerprint recording is tested in handler tests
+        }
+
+        @Override
         public void recordCompleted(long btxId) {
             this.recordCompletedAttemptCount++;
             this.beforeMarkingCompleted(btxId);

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/AddKeyToVerificationQueueCommandHandlerTest.java
@@ -12,7 +12,9 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import io.github.bmarwell.keyserver.application.api.commands.AddKeyToVerificationQueueCommand;
 import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
 import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
+import io.github.bmarwell.keyserver.application.core.concurrent.BusinessTransactionContext;
 import io.github.bmarwell.keyserver.application.port.notification.VerificationNotificationPort;
+import io.github.bmarwell.keyserver.application.port.repository.BusinessTransactionRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationRequest;
 import java.io.IOException;
@@ -22,12 +24,33 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class AddKeyToVerificationQueueCommandHandlerTest {
 
-    /** Fake repository that records every enqueue call and returns sequential IDs. */
+    /** Fake BTX repository that records fingerprint writes. */
+    static class FakeBusinessTransactionRepository implements BusinessTransactionRepository {
+        @Nullable
+        String recordedFingerprint;
+
+        @Override
+        public void recordStarted(long btxId, String commandType, @Nullable String callerIp) {}
+
+        @Override
+        public void recordFingerprint(long btxId, String fingerprint) {
+            this.recordedFingerprint = fingerprint;
+        }
+
+        @Override
+        public void recordCompleted(long btxId) {}
+
+        @Override
+        public void recordFailed(long btxId, String errorType, @Nullable String errorMessage) {}
+    }
+
+    /** Fake verification-queue repository that records every enqueue call and returns sequential IDs. */
     static class FakeVerificationQueueRepository implements VerificationQueueRepository {
         final List<VerificationRequest> received = new ArrayList<>();
         private final AtomicLong counter = new AtomicLong(1_000L);
@@ -61,15 +84,21 @@ class AddKeyToVerificationQueueCommandHandlerTest {
 
     FakeVerificationQueueRepository fakeRepo;
     FakeNotificationPort fakeNotification;
+    FakeBusinessTransactionRepository fakeBtxRepo;
     AddKeyToVerificationQueueCommandHandler handler;
 
     @BeforeEach
     void setUp() {
         this.fakeRepo = new FakeVerificationQueueRepository();
         this.fakeNotification = new FakeNotificationPort();
+        this.fakeBtxRepo = new FakeBusinessTransactionRepository();
+        var btxContext = new BusinessTransactionContext();
+        btxContext.initialize(42L);
         this.handler = new AddKeyToVerificationQueueCommandHandler();
         this.handler.setVerificationQueueRepository(this.fakeRepo);
         this.handler.setNotificationPort(this.fakeNotification);
+        this.handler.setBtxRepository(this.fakeBtxRepo);
+        this.handler.setBtxContext(btxContext);
     }
 
     private String loadTestKey(String resourceName) throws IOException {
@@ -79,6 +108,23 @@ class AddKeyToVerificationQueueCommandHandlerTest {
                     .isNotNull();
             return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+
+    @Test
+    void happy_path_records_fingerprint_on_btx_row() throws IOException {
+        // given
+        // The fingerprint column allows operators to filter the BTX audit log by key; it must be set
+        // by the handler once the key is parsed and verified, so it survives even if later steps fail.
+        String keyText = loadTestKey("test-key-with-email.asc");
+        var command = new AddKeyToVerificationQueueCommand(keyText);
+
+        // when
+        this.handler.execute(command, CommandCallerContext.empty());
+
+        // then
+        assertThat(this.fakeBtxRepo.recordedFingerprint)
+                .as("the handler must write the primary key fingerprint to the BTX audit row")
+                .isNotBlank();
     }
 
     @Test

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
@@ -179,6 +179,25 @@ class VerifyUidCommandHandlerTest {
     // -----------------------------------------------------------------------
 
     @Test
+    void scenario2_expired_token_still_records_fingerprint_on_btx_row() {
+        // given
+        // Even for expired tokens, the BTX row should carry the fingerprint so operators can
+        // correlate failed/expired verification attempts with a specific key in the audit log.
+        this.fakeQueue.put(TOKEN_1, expiredEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+
+        // when
+        assertThatThrownBy(() -> this.handler.execute(
+                        new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty()))
+                .isInstanceOf(TokenExpiredException.class);
+
+        // then
+        assertThat(this.fakeBtxRepo.recordedFingerprint)
+                .as(
+                        "fingerprint must be recorded before the expiry check so expired-token BTX rows are filterable by key")
+                .isEqualTo(FINGERPRINT);
+    }
+
+    @Test
     void scenario2_expired_token_throws_TokenExpiredException() {
         fakeQueue.put(TOKEN_1, expiredEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
 

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
@@ -12,6 +12,8 @@ import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContex
 import io.github.bmarwell.keyserver.application.api.commands.VerifyUidCommand;
 import io.github.bmarwell.keyserver.application.api.ex.TokenExpiredException;
 import io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException;
+import io.github.bmarwell.keyserver.application.core.concurrent.BusinessTransactionContext;
+import io.github.bmarwell.keyserver.application.port.repository.BusinessTransactionRepository;
 import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
 import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationEntry;
@@ -25,6 +27,7 @@ import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -102,6 +105,26 @@ class VerifyUidCommandHandlerTest {
         }
     }
 
+    /** Fake BTX repository that records fingerprint writes. */
+    static class FakeBusinessTransactionRepository implements BusinessTransactionRepository {
+        @Nullable
+        String recordedFingerprint;
+
+        @Override
+        public void recordStarted(long btxId, String commandType, @Nullable String callerIp) {}
+
+        @Override
+        public void recordFingerprint(long btxId, String fingerprint) {
+            this.recordedFingerprint = fingerprint;
+        }
+
+        @Override
+        public void recordCompleted(long btxId) {}
+
+        @Override
+        public void recordFailed(long btxId, String errorType, @Nullable String errorMessage) {}
+    }
+
     // -----------------------------------------------------------------------
     // Fixture helpers
     // -----------------------------------------------------------------------
@@ -134,15 +157,21 @@ class VerifyUidCommandHandlerTest {
 
     FakeVerificationQueueRepository fakeQueue;
     FakeKeyRepository fakeKeys;
+    FakeBusinessTransactionRepository fakeBtxRepo;
     VerifyUidCommandHandler handler;
 
     @BeforeEach
     void setUp() {
-        fakeQueue = new FakeVerificationQueueRepository();
-        fakeKeys = new FakeKeyRepository();
-        handler = new VerifyUidCommandHandler();
-        handler.setVerificationQueueRepository(fakeQueue);
-        handler.setKeyRepository(fakeKeys);
+        this.fakeQueue = new FakeVerificationQueueRepository();
+        this.fakeKeys = new FakeKeyRepository();
+        this.fakeBtxRepo = new FakeBusinessTransactionRepository();
+        var btxContext = new BusinessTransactionContext();
+        btxContext.initialize(42L);
+        this.handler = new VerifyUidCommandHandler();
+        this.handler.setVerificationQueueRepository(this.fakeQueue);
+        this.handler.setKeyRepository(this.fakeKeys);
+        this.handler.setBtxRepository(this.fakeBtxRepo);
+        this.handler.setBtxContext(btxContext);
     }
 
     // -----------------------------------------------------------------------
@@ -164,6 +193,22 @@ class VerifyUidCommandHandlerTest {
     // -----------------------------------------------------------------------
     // Scenario 3: one email address, link clicked → key published
     // -----------------------------------------------------------------------
+
+    @Test
+    void scenario3_records_fingerprint_on_btx_row() {
+        // given
+        // The fingerprint column lets operators filter the BTX audit log by key; the handler must
+        // write it once the verification-queue entry (which already carries the fingerprint) is loaded.
+        this.fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+
+        // when
+        this.handler.execute(new VerifyUidCommand(Long.toUnsignedString(TOKEN_1)), CommandCallerContext.empty());
+
+        // then
+        assertThat(this.fakeBtxRepo.recordedFingerprint)
+                .as("the handler must write the key fingerprint to the BTX audit row after loading the queue entry")
+                .isEqualTo(FINGERPRINT);
+    }
 
     @Test
     void scenario3_single_email_clicked_publishes_key() {

--- a/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/BusinessTransactionRepository.java
+++ b/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/BusinessTransactionRepository.java
@@ -22,6 +22,16 @@ public interface BusinessTransactionRepository {
     /// @param callerIp    remote address of the HTTP client, or `null`
     void recordStarted(long btxId, String commandType, @Nullable String callerIp);
 
+    /// Associates a key fingerprint with an existing BTX row.
+    ///
+    /// Called by command handlers once the fingerprint is known (after parsing or
+    /// loading the key).  Uses `REQUIRES_NEW` so the update commits independently
+    /// of the handler's own JTA transaction.
+    ///
+    /// @param btxId       TSID of the BTX row created by {@link #recordStarted}
+    /// @param fingerprint hex fingerprint of the primary key
+    void recordFingerprint(long btxId, String fingerprint);
+
     /// Updates the row to state `COMPLETED` and sets `completed_at`.
     void recordCompleted(long btxId);
 

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/PersistentBusinessTransactionRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/PersistentBusinessTransactionRepository.java
@@ -37,8 +37,12 @@ public class PersistentBusinessTransactionRepository extends BaseRepository impl
         BusinessTransactionEntity entity = getEntityManager().find(BusinessTransactionEntity.class, btxId);
         if (entity != null) {
             entity.markFingerprintSet(fingerprint);
+            LOG.log(Level.FINE, "BTX {0} fingerprint set [{1}]", new Object[] {btxId, fingerprint});
+        } else {
+            LOG.log(Level.WARNING, "BTX {0} not found when recording fingerprint [{1}]", new Object[] {
+                btxId, fingerprint
+            });
         }
-        LOG.log(Level.FINE, "BTX {0} fingerprint set [{1}]", new Object[] {btxId, fingerprint});
     }
 
     @Override

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/PersistentBusinessTransactionRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/PersistentBusinessTransactionRepository.java
@@ -33,6 +33,16 @@ public class PersistentBusinessTransactionRepository extends BaseRepository impl
 
     @Override
     @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public void recordFingerprint(long btxId, String fingerprint) {
+        BusinessTransactionEntity entity = getEntityManager().find(BusinessTransactionEntity.class, btxId);
+        if (entity != null) {
+            entity.markFingerprintSet(fingerprint);
+        }
+        LOG.log(Level.FINE, "BTX {0} fingerprint set [{1}]", new Object[] {btxId, fingerprint});
+    }
+
+    @Override
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
     public void recordCompleted(long btxId) {
         BusinessTransactionEntity entity = getEntityManager().find(BusinessTransactionEntity.class, btxId);
         if (entity != null) {

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/BusinessTransactionEntity.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/BusinessTransactionEntity.java
@@ -87,6 +87,10 @@ public class BusinessTransactionEntity {
         return entity;
     }
 
+    public void markFingerprintSet(String fingerprint) {
+        this.fingerprint = fingerprint;
+    }
+
     public void markCompleted() {
         this.state = BusinessTransactionState.COMPLETED;
         this.completedAt = OffsetDateTime.now();

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/BusinessTransactionEntity.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/BusinessTransactionEntity.java
@@ -115,10 +115,6 @@ public class BusinessTransactionEntity {
         return Optional.ofNullable(fingerprint);
     }
 
-    public void setFingerprint(String fingerprint) {
-        this.fingerprint = fingerprint;
-    }
-
     public Optional<String> getCallerIp() {
         return Optional.ofNullable(callerIp);
     }


### PR DESCRIPTION
Closes #139

## Changes

- Added `recordFingerprint(long btxId, String fingerprint)` to `BusinessTransactionRepository` port
- `PersistentBusinessTransactionRepository` implements it with `@Transactional(REQUIRES_NEW)`
- `BusinessTransactionEntity.markFingerprintSet(String)` updates the entity
- `AddKeyToVerificationQueueCommandHandler` calls it after parsing, using the primary key fingerprint
- `VerifyUidCommandHandler` calls it after loading the queue entry, using the entry fingerprint
- Tests: `FakeBusinessTransactionRepository` added to both handler test classes; fingerprint-assertion tests added for both happy paths

## Why

The `fingerprint` column existed in the DB schema but was never written, making it impossible to filter the BTX audit log by PGP key.
