### PR TITLE
feat: implement HKP op=index (#137)

### DIFF
--- a/.github/AGENTS.adoc
+++ b/.github/AGENTS.adoc
@@ -160,6 +160,17 @@ Every mutating command is wrapped in a BTX lifecycle:
 * Use `@Nullable` sparingly and only at boundaries that genuinely allow absence.
 * Prefer `Optional` instead of `@Nullable` for return types.
 * Never use `Optional` in fields, and avoid `Optional` parameters unless there is no cleaner API shape.
++
+[NOTE]
+====
+*Exception — immutable DTO record components:* `Optional<T>` is acceptable as a record _component_ when all of the
+following hold: (a) the record is an immutable value-type DTO that is never persisted or serialized to an external
+format, (b) the optionality is an intrinsic part of the domain concept (e.g. `expirationTime` that may genuinely be
+absent), and (c) there is no natural sentinel or null-object alternative.
+`KeyIndexResult` and `UidIndexEntry` satisfy these criteria — they are transient application-layer DTOs consumed and
+discarded within a single request, never mapped by JPA or written to JSON/XML.
+JPA entity fields and any class with `@XmlRootElement`, `@JsonSerialize`, or similar must still not use `Optional`.
+====
 * Avoid mixing docs, refactors, and behavior changes unless the task needs it.
 * After each Java or `pom.xml` change, run `./mvnw spotless:apply`.
 

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/KeyIndexResult.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/KeyIndexResult.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.api;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/// Full index entry for one key, used in `op=index` responses.
+///
+/// Contains the key metadata fields needed for the HKP machine-readable
+/// format (`pub:` line) plus all verified UIDs (`uid:` lines).
+/// Only verified UIDs appear in {@code verifiedUids} — unverified UIDs
+/// are never exposed.
+public record KeyIndexResult(
+        String fingerprint,
+        int algorithm,
+        Optional<Integer> bitStrength,
+        OffsetDateTime creationTime,
+        Optional<OffsetDateTime> expirationTime,
+        boolean revoked,
+        List<UidIndexEntry> verifiedUids) {}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/KeyIndexResult.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/KeyIndexResult.java
@@ -15,6 +15,10 @@ import java.util.Optional;
 /// format (`pub:` line) plus all verified UIDs (`uid:` lines).
 /// Only verified UIDs appear in {@code verifiedUids} — unverified UIDs
 /// are never exposed.
+///
+/// The {@code disabled} flag is a keyserver-administrative flag (HKP `d`).
+/// It is independent of the OpenPGP {@code revoked} flag: an operator may
+/// disable a key on this server without the key owner having revoked it.
 public record KeyIndexResult(
         String fingerprint,
         int algorithm,
@@ -22,4 +26,5 @@ public record KeyIndexResult(
         OffsetDateTime creationTime,
         Optional<OffsetDateTime> expirationTime,
         boolean revoked,
+        boolean disabled,
         List<UidIndexEntry> verifiedUids) {}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/KeyRepositoryService.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/KeyRepositoryService.java
@@ -8,6 +8,7 @@ package io.github.bmarwell.keyserver.application.api;
 import io.github.bmarwell.keyserver.common.ids.KeyId;
 import io.github.bmarwell.keyserver.common.ids.PgpPublicKey;
 import io.github.bmarwell.keyserver.common.ids.RepositoryName;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -30,4 +31,14 @@ public interface KeyRepositoryService {
     /// @param search     HKP search string
     /// @param exactMatch if true, only exact fingerprint or email matches are returned
     Optional<String> getArmoredKeyBySearch(String search, boolean exactMatch);
+
+    /// Searches for all matching keys and returns their index metadata for `op=index` responses.
+    ///
+    /// Uses the same search routing as {@link #getArmoredKeyBySearch} but returns all matching
+    /// keys (not just the first) along with algorithm, timestamp, and verified-UID metadata
+    /// needed to render the HKP machine-readable index format.
+    ///
+    /// @param search     HKP search string
+    /// @param exactMatch if true, only exact fingerprint or email matches are returned
+    List<KeyIndexResult> searchForIndex(String search, boolean exactMatch);
 }

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/UidIndexEntry.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/UidIndexEntry.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.api;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+/// Metadata for a single verified UID, used in `op=index` responses.
+///
+/// All timestamps are `Optional` because UID packets do not always carry
+/// creation/expiration data (older keys often omit them).
+public record UidIndexEntry(
+        String uidRaw,
+        Optional<OffsetDateTime> creationTime,
+        Optional<OffsetDateTime> expirationTime,
+        boolean revoked) {}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/package-info.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+
+/// Primary application port: service interfaces and shared query result types.
+///
+/// All types in this package are non-null by default (jspecify `@NullMarked`).
+/// Fields and parameters that may be `null` are explicitly annotated with
+/// {@link org.jspecify.annotations.Nullable}.
+@NullMarked
+package io.github.bmarwell.keyserver.application.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/PersistentKeyRepositoryService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/PersistentKeyRepositoryService.java
@@ -5,6 +5,7 @@
  */
 package io.github.bmarwell.keyserver.application.core;
 
+import io.github.bmarwell.keyserver.application.api.KeyIndexResult;
 import io.github.bmarwell.keyserver.application.api.KeyRepositoryService;
 import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
 import io.github.bmarwell.keyserver.common.ids.KeyId;
@@ -14,6 +15,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Inject;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Optional;
 
 @Default
@@ -36,6 +38,11 @@ public class PersistentKeyRepositoryService implements KeyRepositoryService, Ser
     @Override
     public Optional<String> getArmoredKeyBySearch(String search, boolean exactMatch) {
         return keyRepository.findBySearch(search, exactMatch).map(KeyRepository.KeySearchResult::armoredKey);
+    }
+
+    @Override
+    public List<KeyIndexResult> searchForIndex(String search, boolean exactMatch) {
+        return this.keyRepository.findManyBySearch(search, exactMatch);
     }
 
     // CDI-friendly setter for unit testing

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/cmdhandler/VerifyUidCommandHandlerTest.java
@@ -63,6 +63,12 @@ class VerifyUidCommandHandlerTest {
         public Optional<KeySearchResult> findBySearch(String search, boolean exactMatch) {
             return Optional.empty();
         }
+
+        @Override
+        public List<io.github.bmarwell.keyserver.application.api.KeyIndexResult> findManyBySearch(
+                String search, boolean exactMatch) {
+            return List.of();
+        }
     }
 
     /**

--- a/application/application-ports/application-port-repository/pom.xml
+++ b/application/application-ports/application-port-repository/pom.xml
@@ -13,4 +13,12 @@
   <version>0.1.0-SNAPSHOT</version>
   <name>Java Keyserver :: application :: port :: repository</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.github.bmarwell.keyserver</groupId>
+      <artifactId>keyserver-application-api</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/KeyRepository.java
+++ b/application/application-ports/application-port-repository/src/main/java/io/github/bmarwell/keyserver/application/port/repository/KeyRepository.java
@@ -5,6 +5,8 @@
  */
 package io.github.bmarwell.keyserver.application.port.repository;
 
+import io.github.bmarwell.keyserver.application.api.KeyIndexResult;
+import java.util.List;
 import java.util.Optional;
 
 /// Secondary (outbound) port for the published key store.
@@ -17,7 +19,7 @@ public interface KeyRepository {
 
     /// Result type returned by key search queries.
     ///
-    /// Contains the minimal data required by the HKP `op=get` and `op=index` responses.
+    /// Contains the minimal data required by the HKP `op=get` response.
     /// The `armoredKey` field holds only the verified UIDs (privacy-preserving, per
     /// {@link #publishVerifiedUid} contract).
     record KeySearchResult(String fingerprint, String armoredKey) {}
@@ -52,4 +54,17 @@ public interface KeyRepository {
     /// @param search     HKP search string
     /// @param exactMatch when true, only exact fingerprint/email matches are returned
     Optional<KeySearchResult> findBySearch(String search, boolean exactMatch);
+
+    /// Searches for keys by fingerprint, key ID, email address, or UID substring and returns
+    /// full index metadata for all matching keys.
+    ///
+    /// Uses the same search routing as {@link #findBySearch} but returns all matching keys
+    /// (not limited to the first) and includes per-key algorithm, timestamp, and verified-UID
+    /// metadata needed to render HKP `op=index` responses.
+    ///
+    /// Only verified UIDs are included in each {@link KeyIndexResult#verifiedUids()} list.
+    ///
+    /// @param search     HKP search string
+    /// @param exactMatch when true, only exact fingerprint/email matches are returned
+    List<KeyIndexResult> findManyBySearch(String search, boolean exactMatch);
 }

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
@@ -5,6 +5,8 @@
  */
 package io.github.bmarwell.keyserver.repository;
 
+import io.github.bmarwell.keyserver.application.api.KeyIndexResult;
+import io.github.bmarwell.keyserver.application.api.UidIndexEntry;
 import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
 import io.github.bmarwell.keyserver.application.port.repository.KeyRepository.KeySearchResult;
 import io.github.bmarwell.keyserver.repository.entity.KeyEntity;
@@ -151,6 +153,30 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
         return findByUidSubstring(normalized);
     }
 
+    @Override
+    @Transactional
+    public List<KeyIndexResult> findManyBySearch(String search, boolean exactMatch) {
+        if (search == null || search.isBlank()) {
+            return List.of();
+        }
+
+        String normalized = search.strip();
+
+        String hexCandidate = normalized.startsWith("0x") ? normalized.substring(2) : normalized;
+        if ((normalized.startsWith("0x") || isHexString(hexCandidate)) && isValidKeyIdLength(hexCandidate.length())) {
+            return findManyByKeyIdOrFingerprint(hexCandidate);
+        }
+
+        if (normalized.contains("@")) {
+            return findManyByEmail(normalized.toLowerCase(Locale.ROOT), exactMatch);
+        }
+
+        if (exactMatch) {
+            return List.of();
+        }
+        return findManyByUidSubstring(normalized);
+    }
+
     private Optional<KeySearchResult> findByKeyIdOrFingerprint(String hexValue) {
         // Normalise to uppercase: fingerprint (and the DB-generated keyid_long column) are stored
         // as uppercase.  Avoiding LOWER() on the column allows the DB to use the keys_keyid_long
@@ -159,12 +185,10 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
         int len = upper.length();
 
         if (len == 40 || len == 64) {
-            // Full fingerprint — primary key lookup (always indexed).
             return toResult(getEntityManager().find(KeyEntity.class, upper));
         }
 
         if (len == 16) {
-            // Long key ID: exact match on the generated keyid_long column (uses keys_keyid_long index).
             List<KeyEntity> results = getEntityManager()
                     .createQuery("SELECT k FROM KeyEntity k WHERE k.keyidLong = :keyId", KeyEntity.class)
                     .setParameter("keyId", upper)
@@ -174,8 +198,7 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
         }
 
         // Short key ID (8 chars): reverse it and use the rfingerprint text_pattern_ops index for a
-        // prefix scan.  reverse(fingerprint) starts with reverse(shortKeyId), so this matches the
-        // last 8 chars of the fingerprint without a leading-wildcard LIKE on the forward column.
+        // prefix scan.
         String reversedShortId = new StringBuilder(upper).reverse().toString();
         List<KeyEntity> results = getEntityManager()
                 .createQuery("SELECT k FROM KeyEntity k WHERE k.rfingerprint LIKE :prefix", KeyEntity.class)
@@ -185,31 +208,85 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
         return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
     }
 
+    private List<KeyIndexResult> findManyByKeyIdOrFingerprint(String hexValue) {
+        String upper = hexValue.toUpperCase(Locale.ROOT);
+        int len = upper.length();
+
+        if (len == 40 || len == 64) {
+            // Full fingerprint — primary key lookup (always indexed).
+            KeyEntity entity = getEntityManager().find(KeyEntity.class, upper);
+            return toIndexResults(entity == null ? List.of() : List.of(entity));
+        }
+
+        if (len == 16) {
+            // Long key ID: exact match on the generated keyid_long column (uses keys_keyid_long index).
+            List<KeyEntity> results = getEntityManager()
+                    .createQuery("SELECT k FROM KeyEntity k WHERE k.keyidLong = :keyId", KeyEntity.class)
+                    .setParameter("keyId", upper)
+                    .getResultList();
+            return toIndexResults(results);
+        }
+
+        // Short key ID (8 chars): reverse it and use the rfingerprint text_pattern_ops index for a
+        // prefix scan.  reverse(fingerprint) starts with reverse(shortKeyId), so this matches the
+        // last 8 chars of the fingerprint without a leading-wildcard LIKE on the forward column.
+        String reversedShortId = new StringBuilder(upper).reverse().toString();
+        List<KeyEntity> results = getEntityManager()
+                .createQuery("SELECT k FROM KeyEntity k WHERE k.rfingerprint LIKE :prefix", KeyEntity.class)
+                .setParameter("prefix", reversedShortId + "%")
+                .getResultList();
+        return toIndexResults(results);
+    }
+
     private Optional<KeySearchResult> findByEmail(String email, boolean exactMatch) {
+        List<KeyEntity> results = queryEntitiesByEmail(email, exactMatch, 1);
+        return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
+    }
+
+    private List<KeyIndexResult> findManyByEmail(String email, boolean exactMatch) {
+        return toIndexResults(queryEntitiesByEmail(email, exactMatch, Integer.MAX_VALUE));
+    }
+
+    /// Returns KeyEntity rows for a given email filter.
+    ///
+    /// Keeps the JPQL in one place so both the single-result and multi-result paths
+    /// stay in sync when the schema changes.
+    private List<KeyEntity> queryEntitiesByEmail(String email, boolean exactMatch, int maxResults) {
         String jpql = exactMatch
                 ? "SELECT DISTINCT k FROM KeyEntity k JOIN k.uids u"
                         + " WHERE LOWER(u.uidEmail) = :email AND u.verified = true"
                 : "SELECT DISTINCT k FROM KeyEntity k JOIN k.uids u"
                         + " WHERE LOWER(u.uidEmail) LIKE :email AND u.verified = true";
         String param = exactMatch ? email : "%" + email + "%";
-        List<KeyEntity> results = getEntityManager()
+        return getEntityManager()
                 .createQuery(jpql, KeyEntity.class)
                 .setParameter("email", param)
-                .setMaxResults(1)
+                .setMaxResults(maxResults)
                 .getResultList();
-        return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
     }
 
     private Optional<KeySearchResult> findByUidSubstring(String term) {
-        List<KeyEntity> results = getEntityManager()
+        List<KeyEntity> results = queryEntitiesByUidSubstring(term, 1);
+        return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
+    }
+
+    private List<KeyIndexResult> findManyByUidSubstring(String term) {
+        return toIndexResults(queryEntitiesByUidSubstring(term, Integer.MAX_VALUE));
+    }
+
+    /// Returns KeyEntity rows whose raw UID text contains the given term (case-insensitive).
+    ///
+    /// Keeps the JPQL in one place so both the single-result and multi-result paths
+    /// stay in sync when the schema changes.
+    private List<KeyEntity> queryEntitiesByUidSubstring(String term, int maxResults) {
+        return getEntityManager()
                 .createQuery(
                         "SELECT DISTINCT k FROM KeyEntity k JOIN k.uids u"
                                 + " WHERE LOWER(u.uidRaw) LIKE :term AND u.verified = true",
                         KeyEntity.class)
                 .setParameter("term", "%" + term.toLowerCase(Locale.ROOT) + "%")
-                .setMaxResults(1)
+                .setMaxResults(maxResults)
                 .getResultList();
-        return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
     }
 
     private static Optional<KeySearchResult> toResult(KeyEntity key) {
@@ -217,6 +294,26 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
             return Optional.empty();
         }
         return Optional.of(new KeySearchResult(key.getFingerprint(), key.getArmoredKey()));
+    }
+
+    private static List<KeyIndexResult> toIndexResults(List<KeyEntity> keys) {
+        return keys.stream().map(JpaKeyRepository::toIndexResult).toList();
+    }
+
+    private static KeyIndexResult toIndexResult(KeyEntity key) {
+        List<UidIndexEntry> uids = key.getUids().stream()
+                .filter(UidEntity::isVerified)
+                .map(u -> new UidIndexEntry(u.getUidRaw(), u.getCreationTime(), u.getExpirationTime(), u.isRevoked()))
+                .toList();
+
+        return new KeyIndexResult(
+                key.getFingerprint(),
+                key.getAlgorithm(),
+                key.getBitStrength(),
+                key.getCreationTime(),
+                key.getExpirationTime(),
+                key.isRevoked(),
+                uids);
     }
 
     private static boolean isHexString(String s) {

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
@@ -52,6 +52,14 @@ import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
 @ApplicationScoped
 public class JpaKeyRepository extends BaseRepository implements KeyRepository {
 
+    /// Maximum number of keys returned by multi-result index queries.
+    ///
+    /// A broad search term (e.g. a common email domain or UID substring) could otherwise
+    /// load an unbounded number of key rows — together with their UID collections — into a
+    /// single JPA transaction.  5 000 matches what popular HKP clients are expected to handle
+    /// and prevents memory exhaustion under adversarial inputs.
+    private static final int INDEX_RESULT_LIMIT = 5_000;
+
     @Override
     @Transactional
     public void publishVerifiedUid(String fingerprint, String uidRaw, String uidEmail, String armoredKey) {
@@ -244,13 +252,15 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
     }
 
     private List<KeyIndexResult> findManyByEmail(String email, boolean exactMatch) {
-        return toIndexResults(queryEntitiesByEmail(email, exactMatch, Integer.MAX_VALUE));
+        return toIndexResults(queryEntitiesByEmail(email, exactMatch, INDEX_RESULT_LIMIT));
     }
 
     /// Returns KeyEntity rows for a given email filter.
     ///
     /// Keeps the JPQL in one place so both the single-result and multi-result paths
-    /// stay in sync when the schema changes.
+    /// stay in sync when the schema changes.  Callers that want all results should pass
+    /// {@link #INDEX_RESULT_LIMIT} rather than {@link Integer#MAX_VALUE} to prevent
+    /// unbounded memory use.
     private List<KeyEntity> queryEntitiesByEmail(String email, boolean exactMatch, int maxResults) {
         String jpql = exactMatch
                 ? "SELECT DISTINCT k FROM KeyEntity k JOIN k.uids u"
@@ -271,13 +281,15 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
     }
 
     private List<KeyIndexResult> findManyByUidSubstring(String term) {
-        return toIndexResults(queryEntitiesByUidSubstring(term, Integer.MAX_VALUE));
+        return toIndexResults(queryEntitiesByUidSubstring(term, INDEX_RESULT_LIMIT));
     }
 
     /// Returns KeyEntity rows whose raw UID text contains the given term (case-insensitive).
     ///
     /// Keeps the JPQL in one place so both the single-result and multi-result paths
-    /// stay in sync when the schema changes.
+    /// stay in sync when the schema changes.  Callers that want all results should pass
+    /// {@link #INDEX_RESULT_LIMIT} rather than {@link Integer#MAX_VALUE} to prevent
+    /// unbounded memory use.
     private List<KeyEntity> queryEntitiesByUidSubstring(String term, int maxResults) {
         return getEntityManager()
                 .createQuery(

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
@@ -386,7 +386,10 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
     }
 
     private static List<KeyIndexResult> toIndexResults(List<KeyEntity> keys) {
-        return keys.stream().map(JpaKeyRepository::toIndexResult).toList();
+        return keys.stream()
+                .map(JpaKeyRepository::toIndexResult)
+                .filter(r -> !r.verifiedUids().isEmpty())
+                .toList();
     }
 
     private static KeyIndexResult toIndexResult(KeyEntity key) {

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/JpaKeyRepository.java
@@ -14,6 +14,7 @@ import io.github.bmarwell.keyserver.repository.entity.UidEntity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.TypedQuery;
 import jakarta.transaction.Transactional;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -59,6 +60,24 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
     /// single JPA transaction.  5 000 matches what popular HKP clients are expected to handle
     /// and prevents memory exhaustion under adversarial inputs.
     private static final int INDEX_RESULT_LIMIT = 5_000;
+
+    // -------------------------------------------------------------------------
+    // JPA provider read-only query hints.
+    //
+    // Index queries map results directly to immutable DTOs; the entities are
+    // never written back.  Telling each provider to skip dirty tracking and lock
+    // acquisition reduces heap pressure and eliminates unnecessary lock rows.
+    // Unknown hints are silently ignored by every compliant JPA provider.
+    // -------------------------------------------------------------------------
+
+    /// Hibernate: mark loaded entities as read-only so dirty checking is skipped.
+    private static final String HINT_HIBERNATE_READ_ONLY = "org.hibernate.readOnly";
+
+    /// EclipseLink: detach objects immediately after loading (read-only session).
+    private static final String HINT_ECLIPSELINK_READ_ONLY = "eclipselink.read-only";
+
+    /// Apache OpenJPA: acquire no read lock, reducing contention on index queries.
+    private static final String HINT_OPENJPA_READ_LOCK_MODE = "openjpa.FetchPlan.ReadLockMode";
 
     @Override
     @Transactional
@@ -221,16 +240,24 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
         int len = upper.length();
 
         if (len == 40 || len == 64) {
-            // Full fingerprint — primary key lookup (always indexed).
-            KeyEntity entity = getEntityManager().find(KeyEntity.class, upper);
-            return toIndexResults(entity == null ? List.of() : List.of(entity));
+            // Full fingerprint — switch from em.find() to JPQL so JOIN FETCH eagerly loads UIDs.
+            List<KeyEntity> results = applyReadOnlyHints(getEntityManager()
+                            .createQuery(
+                                    "SELECT DISTINCT k FROM KeyEntity k JOIN FETCH k.uids"
+                                            + " WHERE k.fingerprint = :fp",
+                                    KeyEntity.class)
+                            .setParameter("fp", upper))
+                    .getResultList();
+            return toIndexResults(results);
         }
 
         if (len == 16) {
-            // Long key ID: exact match on the generated keyid_long column (uses keys_keyid_long index).
-            List<KeyEntity> results = getEntityManager()
-                    .createQuery("SELECT k FROM KeyEntity k WHERE k.keyidLong = :keyId", KeyEntity.class)
-                    .setParameter("keyId", upper)
+            List<KeyEntity> results = applyReadOnlyHints(getEntityManager()
+                            .createQuery(
+                                    "SELECT DISTINCT k FROM KeyEntity k JOIN FETCH k.uids"
+                                            + " WHERE k.keyidLong = :keyId",
+                                    KeyEntity.class)
+                            .setParameter("keyId", upper))
                     .getResultList();
             return toIndexResults(results);
         }
@@ -239,9 +266,12 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
         // prefix scan.  reverse(fingerprint) starts with reverse(shortKeyId), so this matches the
         // last 8 chars of the fingerprint without a leading-wildcard LIKE on the forward column.
         String reversedShortId = new StringBuilder(upper).reverse().toString();
-        List<KeyEntity> results = getEntityManager()
-                .createQuery("SELECT k FROM KeyEntity k WHERE k.rfingerprint LIKE :prefix", KeyEntity.class)
-                .setParameter("prefix", reversedShortId + "%")
+        List<KeyEntity> results = applyReadOnlyHints(getEntityManager()
+                        .createQuery(
+                                "SELECT DISTINCT k FROM KeyEntity k JOIN FETCH k.uids"
+                                        + " WHERE k.rfingerprint LIKE :prefix",
+                                KeyEntity.class)
+                        .setParameter("prefix", reversedShortId + "%"))
                 .getResultList();
         return toIndexResults(results);
     }
@@ -252,15 +282,14 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
     }
 
     private List<KeyIndexResult> findManyByEmail(String email, boolean exactMatch) {
-        return toIndexResults(queryEntitiesByEmail(email, exactMatch, INDEX_RESULT_LIMIT));
+        List<String> fingerprints = queryFingerprintsByEmail(email, exactMatch);
+        return fingerprints.isEmpty() ? List.of() : fetchIndexResultsByFingerprints(fingerprints);
     }
 
-    /// Returns KeyEntity rows for a given email filter.
+    /// Returns at most one KeyEntity row for a given email filter (single-result path).
     ///
-    /// Keeps the JPQL in one place so both the single-result and multi-result paths
-    /// stay in sync when the schema changes.  Callers that want all results should pass
-    /// {@link #INDEX_RESULT_LIMIT} rather than {@link Integer#MAX_VALUE} to prevent
-    /// unbounded memory use.
+    /// Keeps the JPQL in one place; callers must always pass {@code maxResults = 1}.
+    /// The multi-result path uses {@link #queryFingerprintsByEmail} instead.
     private List<KeyEntity> queryEntitiesByEmail(String email, boolean exactMatch, int maxResults) {
         String jpql = exactMatch
                 ? "SELECT DISTINCT k FROM KeyEntity k JOIN k.uids u"
@@ -275,21 +304,40 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
                 .getResultList();
     }
 
+    /// First query of the two-query pattern for email index searches.
+    ///
+    /// Selects fingerprints only (no collection fetch) so that {@link #INDEX_RESULT_LIMIT}
+    /// is applied correctly at the SQL level.  The caller then passes the fingerprint list
+    /// to {@link #fetchIndexResultsByFingerprints} which loads the full entity graph
+    /// via {@code JOIN FETCH} without any conflicting pagination.
+    private List<String> queryFingerprintsByEmail(String email, boolean exactMatch) {
+        String jpql = exactMatch
+                ? "SELECT DISTINCT k.fingerprint FROM KeyEntity k JOIN k.uids u"
+                        + " WHERE LOWER(u.uidEmail) = :email AND u.verified = true"
+                : "SELECT DISTINCT k.fingerprint FROM KeyEntity k JOIN k.uids u"
+                        + " WHERE LOWER(u.uidEmail) LIKE :email AND u.verified = true";
+        String param = exactMatch ? email : "%" + email + "%";
+        return applyReadOnlyHints(getEntityManager()
+                        .createQuery(jpql, String.class)
+                        .setParameter("email", param)
+                        .setMaxResults(INDEX_RESULT_LIMIT))
+                .getResultList();
+    }
+
     private Optional<KeySearchResult> findByUidSubstring(String term) {
         List<KeyEntity> results = queryEntitiesByUidSubstring(term, 1);
         return results.isEmpty() ? Optional.empty() : toResult(results.get(0));
     }
 
     private List<KeyIndexResult> findManyByUidSubstring(String term) {
-        return toIndexResults(queryEntitiesByUidSubstring(term, INDEX_RESULT_LIMIT));
+        List<String> fingerprints = queryFingerprintsByUidSubstring(term);
+        return fingerprints.isEmpty() ? List.of() : fetchIndexResultsByFingerprints(fingerprints);
     }
 
-    /// Returns KeyEntity rows whose raw UID text contains the given term (case-insensitive).
+    /// Returns at most one KeyEntity row whose raw UID text contains the given term (single-result path).
     ///
-    /// Keeps the JPQL in one place so both the single-result and multi-result paths
-    /// stay in sync when the schema changes.  Callers that want all results should pass
-    /// {@link #INDEX_RESULT_LIMIT} rather than {@link Integer#MAX_VALUE} to prevent
-    /// unbounded memory use.
+    /// Callers must always pass {@code maxResults = 1}.
+    /// The multi-result path uses {@link #queryFingerprintsByUidSubstring} instead.
     private List<KeyEntity> queryEntitiesByUidSubstring(String term, int maxResults) {
         return getEntityManager()
                 .createQuery(
@@ -299,6 +347,35 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
                 .setParameter("term", "%" + term.toLowerCase(Locale.ROOT) + "%")
                 .setMaxResults(maxResults)
                 .getResultList();
+    }
+
+    /// First query of the two-query pattern for UID substring index searches.
+    ///
+    /// Selects fingerprints only so {@link #INDEX_RESULT_LIMIT} is applied at the SQL level.
+    private List<String> queryFingerprintsByUidSubstring(String term) {
+        return applyReadOnlyHints(getEntityManager()
+                        .createQuery(
+                                "SELECT DISTINCT k.fingerprint FROM KeyEntity k JOIN k.uids u"
+                                        + " WHERE LOWER(u.uidRaw) LIKE :term AND u.verified = true",
+                                String.class)
+                        .setParameter("term", "%" + term.toLowerCase(Locale.ROOT) + "%")
+                        .setMaxResults(INDEX_RESULT_LIMIT))
+                .getResultList();
+    }
+
+    /// Second query of the two-query pattern: loads full key entities with their UIDs eagerly.
+    ///
+    /// Because the fingerprint list was already bounded by {@link #INDEX_RESULT_LIMIT} in the
+    /// first query, this {@code JOIN FETCH} query has no conflicting pagination and the JPA
+    /// provider can apply the join at the SQL level without in-memory row reduction.
+    private List<KeyIndexResult> fetchIndexResultsByFingerprints(List<String> fingerprints) {
+        List<KeyEntity> entities = applyReadOnlyHints(getEntityManager()
+                        .createQuery(
+                                "SELECT DISTINCT k FROM KeyEntity k JOIN FETCH k.uids" + " WHERE k.fingerprint IN :fps",
+                                KeyEntity.class)
+                        .setParameter("fps", fingerprints))
+                .getResultList();
+        return toIndexResults(entities);
     }
 
     private static Optional<KeySearchResult> toResult(KeyEntity key) {
@@ -325,7 +402,29 @@ public class JpaKeyRepository extends BaseRepository implements KeyRepository {
                 key.getCreationTime(),
                 key.getExpirationTime(),
                 key.isRevoked(),
+                key.isDisabled(),
                 uids);
+    }
+
+    /// Applies read-only query hints for the three major JPA providers.
+    ///
+    /// Index queries map results directly to immutable {@link KeyIndexResult} DTOs —
+    /// the loaded entities are never modified.  Signalling read-only intent allows each
+    /// provider to skip dirty tracking and lock acquisition:
+    /// <ul>
+    ///   <li>Hibernate ({@code org.hibernate.readOnly = true}): skips snapshot creation and
+    ///       dirty checking at flush time.</li>
+    ///   <li>EclipseLink ({@code eclipselink.read-only = true}): detaches objects immediately,
+    ///       preventing them from entering the identity map.</li>
+    ///   <li>Apache OpenJPA ({@code openjpa.FetchPlan.ReadLockMode = "NONE"}): suppresses
+    ///       implicit read-lock acquisition on each loaded row.</li>
+    /// </ul>
+    /// Unknown hints are silently ignored by all compliant JPA providers, so this method
+    /// is safe to call regardless of which provider is active at runtime.
+    private static <T> TypedQuery<T> applyReadOnlyHints(TypedQuery<T> query) {
+        return query.setHint(HINT_HIBERNATE_READ_ONLY, Boolean.TRUE)
+                .setHint(HINT_ECLIPSELINK_READ_ONLY, Boolean.TRUE)
+                .setHint(HINT_OPENJPA_READ_LOCK_MODE, "NONE");
     }
 
     private static boolean isHexString(String s) {

--- a/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/KeyEntity.java
+++ b/repository/src/main/java/io/github/bmarwell/keyserver/repository/entity/KeyEntity.java
@@ -59,6 +59,12 @@ public class KeyEntity {
     @Column(name = "revoked", nullable = false)
     private boolean revoked;
 
+    /// Keyserver-administrative flag: true if a keyserver operator has explicitly
+    /// disabled this key.  Unlike {@code revoked}, this flag is not set by the key
+    /// owner and is not reflected in the OpenPGP key material.
+    @Column(name = "disabled", nullable = false)
+    private boolean disabled;
+
     /// Full ASCII-armored public key block returned verbatim on `op=get`.
     @Column(name = "armored_key", nullable = false)
     private String armoredKey;
@@ -140,6 +146,15 @@ public class KeyEntity {
 
     public void setRevoked(boolean revoked) {
         this.revoked = revoked;
+        this.mtime = OffsetDateTime.now();
+    }
+
+    public boolean isDisabled() {
+        return disabled;
+    }
+
+    public void setDisabled(boolean disabled) {
+        this.disabled = disabled;
         this.mtime = OffsetDateTime.now();
     }
 

--- a/repository/src/main/resources/io/github/bmarwell/keyserver/repository/migrations/V010__add-disabled-flag-to-keys.sql
+++ b/repository/src/main/resources/io/github/bmarwell/keyserver/repository/migrations/V010__add-disabled-flag-to-keys.sql
@@ -1,0 +1,5 @@
+-- Add keyserver-level 'disabled' flag to the keys table.
+-- A disabled key is hidden from op=index and op=get results but is not revoked
+-- in the OpenPGP sense; the flag is set by keyserver administrators only.
+-- Defaults to FALSE so all existing keys remain visible after the migration.
+ALTER TABLE keys ADD COLUMN disabled BOOLEAN NOT NULL DEFAULT FALSE;

--- a/repository/src/main/resources/io/github/bmarwell/keyserver/repository/migrations/V010__add-disabled-flag-to-keys.sql
+++ b/repository/src/main/resources/io/github/bmarwell/keyserver/repository/migrations/V010__add-disabled-flag-to-keys.sql
@@ -1,5 +1,5 @@
 -- Add keyserver-level 'disabled' flag to the keys table.
--- A disabled key is hidden from op=index and op=get results but is not revoked
+-- A disabled key is shown in op=index results with the 'd' flag but is not revoked
 -- in the OpenPGP sense; the flag is set by keyserver administrators only.
 -- Defaults to FALSE so all existing keys remain visible after the migration.
 ALTER TABLE keys ADD COLUMN disabled BOOLEAN NOT NULL DEFAULT FALSE;

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import io.github.bmarwell.keyserver.application.api.KeyIndexResult;
+import io.github.bmarwell.keyserver.application.api.UidIndexEntry;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/// Renders HKP `op=index` responses in machine-readable and HTML formats.
+///
+/// Machine-readable format (`options=mr`) follows the HKP draft specification:
+/// each key block starts with a `pub:` line containing fingerprint, algorithm, key length,
+/// creation timestamp, expiration timestamp, and flags.  Each verified UID follows as a
+/// `uid:` line.  The response begins with an `info:` header line.
+///
+/// The HTML format is a simple table — sufficient for browser inspection but not required
+/// for GnuPG interoperability.
+@ApplicationScoped
+public class HkpIndexRenderer {
+
+    /// Renders the machine-readable HKP index format (`options=mr`).
+    ///
+    /// Format per the HKP draft:
+    /// <pre>
+    /// info:1:&lt;count&gt;
+    /// pub:&lt;fingerprint&gt;:&lt;algo&gt;:&lt;keylen&gt;:&lt;ctime&gt;:&lt;exptime&gt;:&lt;flags&gt;
+    /// uid:&lt;pct-encoded-uid&gt;:&lt;ctime&gt;:&lt;exptime&gt;:&lt;flags&gt;
+    /// </pre>
+    ///
+    /// Flags: `r` if revoked, `e` if expired (expiration is in the past), or empty.
+    /// Key length is empty for ECC keys (bit strength is null), numeric for RSA/DSA.
+    public String renderMachineReadable(List<KeyIndexResult> results) {
+        Instant now = Instant.now();
+        StringBuilder sb = new StringBuilder();
+        sb.append("info:1:").append(results.size()).append('\n');
+        for (KeyIndexResult key : results) {
+            sb.append("pub:");
+            sb.append(key.fingerprint()).append(':');
+            sb.append(key.algorithm()).append(':');
+            key.bitStrength().ifPresent(bs -> sb.append(bs));
+            sb.append(':');
+            sb.append(toEpochSeconds(key.creationTime())).append(':');
+            sb.append(key.expirationTime().map(HkpIndexRenderer::toEpochSeconds).orElse(""))
+                    .append(':');
+            sb.append(computeFlags(key.revoked(), key.expirationTime(), now));
+            sb.append('\n');
+            for (UidIndexEntry uid : key.verifiedUids()) {
+                sb.append("uid:");
+                sb.append(URLEncoder.encode(uid.uidRaw(), StandardCharsets.UTF_8))
+                        .append(':');
+                sb.append(uid.creationTime()
+                                .map(HkpIndexRenderer::toEpochSeconds)
+                                .orElse(""))
+                        .append(':');
+                sb.append(uid.expirationTime()
+                                .map(HkpIndexRenderer::toEpochSeconds)
+                                .orElse(""))
+                        .append(':');
+                sb.append(computeFlags(uid.revoked(), uid.expirationTime(), now));
+                sb.append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    /// Renders a simple HTML table for browser display.
+    ///
+    /// The HTML is intentionally minimal — it is not required for GnuPG interoperability
+    /// and is provided as a human-readable fallback only.
+    public String renderHtml(List<KeyIndexResult> results) {
+        Instant now = Instant.now();
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><body><h1>Search results: ").append(results.size()).append(" key(s)</h1>\n");
+        sb.append("<table border=\"1\"><tr><th>Fingerprint</th><th>Algorithm</th>"
+                + "<th>Created</th><th>Expires</th><th>Flags</th><th>UIDs</th></tr>\n");
+        for (KeyIndexResult key : results) {
+            sb.append("<tr>");
+            sb.append("<td>").append(htmlEscape(key.fingerprint())).append("</td>");
+            sb.append("<td>").append(key.algorithm()).append("</td>");
+            sb.append("<td>").append(key.creationTime()).append("</td>");
+            sb.append("<td>")
+                    .append(key.expirationTime().map(Object::toString).orElse(""))
+                    .append("</td>");
+            sb.append("<td>")
+                    .append(computeFlags(key.revoked(), key.expirationTime(), now))
+                    .append("</td>");
+            sb.append("<td>");
+            for (UidIndexEntry uid : key.verifiedUids()) {
+                sb.append(htmlEscape(uid.uidRaw())).append("<br>");
+            }
+            sb.append("</td>");
+            sb.append("</tr>\n");
+        }
+        sb.append("</table></body></html>");
+        return sb.toString();
+    }
+
+    private static String toEpochSeconds(OffsetDateTime dt) {
+        return String.valueOf(dt.toEpochSecond());
+    }
+
+    private static String computeFlags(boolean revoked, Optional<OffsetDateTime> expiration, Instant now) {
+        StringBuilder flags = new StringBuilder();
+        if (revoked) {
+            flags.append('r');
+        }
+        if (expiration.isPresent() && expiration.get().toInstant().isBefore(now)) {
+            flags.append('e');
+        }
+        return flags.toString();
+    }
+
+    private static String htmlEscape(String s) {
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    }
+}

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
@@ -88,7 +88,9 @@ public class HkpIndexRenderer {
     public String renderHtml(List<KeyIndexResult> results) {
         Instant now = Instant.now();
         StringBuilder sb = new StringBuilder();
-        sb.append("<html><body><h1>Search results: ").append(results.size()).append(" key(s)</h1>\n");
+        sb.append("<!DOCTYPE html>\n");
+        sb.append("<html><head><meta charset=\"utf-8\"><title>Key search results</title></head>");
+        sb.append("<body><h1>Search results: ").append(results.size()).append(" key(s)</h1>\n");
         sb.append("<table border=\"1\"><tr><th>Fingerprint</th><th>Algorithm (OpenPGP code)</th>"
                 + "<th>Created</th><th>Expires</th><th>Flags</th><th>UIDs</th></tr>\n");
         for (KeyIndexResult key : results) {

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
@@ -89,7 +89,7 @@ public class HkpIndexRenderer {
         Instant now = Instant.now();
         StringBuilder sb = new StringBuilder();
         sb.append("<html><body><h1>Search results: ").append(results.size()).append(" key(s)</h1>\n");
-        sb.append("<table border=\"1\"><tr><th>Fingerprint</th><th>Algorithm</th>"
+        sb.append("<table border=\"1\"><tr><th>Fingerprint</th><th>Algorithm (OpenPGP code)</th>"
                 + "<th>Created</th><th>Expires</th><th>Flags</th><th>UIDs</th></tr>\n");
         for (KeyIndexResult key : results) {
             sb.append("<tr>");

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
@@ -36,8 +36,11 @@ public class HkpIndexRenderer {
     /// uid:&lt;pct-encoded-uid&gt;:&lt;ctime&gt;:&lt;exptime&gt;:&lt;flags&gt;
     /// </pre>
     ///
-    /// Flags: `r` if revoked, `e` if expired (expiration is in the past), or empty.
+    /// Flags (in spec order): `r` if revoked, `d` if disabled on this keyserver,
+    /// `e` if expired (expiration is in the past), or empty.
     /// Key length is empty for ECC keys (bit strength is null), numeric for RSA/DSA.
+    /// The `d` flag is a keyserver-administrative concept; it does not appear on
+    /// `uid:` lines since UIDs are not disabled independently.
     public String renderMachineReadable(List<KeyIndexResult> results) {
         Instant now = Instant.now();
         StringBuilder sb = new StringBuilder();
@@ -51,7 +54,7 @@ public class HkpIndexRenderer {
             sb.append(toEpochSeconds(key.creationTime())).append(':');
             sb.append(key.expirationTime().map(HkpIndexRenderer::toEpochSeconds).orElse(""))
                     .append(':');
-            sb.append(computeFlags(key.revoked(), key.expirationTime(), now));
+            sb.append(computeFlags(key.revoked(), key.disabled(), key.expirationTime(), now));
             sb.append('\n');
             for (UidIndexEntry uid : key.verifiedUids()) {
                 sb.append("uid:");
@@ -70,7 +73,8 @@ public class HkpIndexRenderer {
                                 .map(HkpIndexRenderer::toEpochSeconds)
                                 .orElse(""))
                         .append(':');
-                sb.append(computeFlags(uid.revoked(), uid.expirationTime(), now));
+                // UIDs are not disabled independently; pass false for the 'd' flag.
+                sb.append(computeFlags(uid.revoked(), false, uid.expirationTime(), now));
                 sb.append('\n');
             }
         }
@@ -96,7 +100,7 @@ public class HkpIndexRenderer {
                     .append(key.expirationTime().map(Object::toString).orElse(""))
                     .append("</td>");
             sb.append("<td>")
-                    .append(computeFlags(key.revoked(), key.expirationTime(), now))
+                    .append(computeFlags(key.revoked(), key.disabled(), key.expirationTime(), now))
                     .append("</td>");
             sb.append("<td>");
             for (UidIndexEntry uid : key.verifiedUids()) {
@@ -113,10 +117,14 @@ public class HkpIndexRenderer {
         return String.valueOf(dt.toEpochSecond());
     }
 
-    private static String computeFlags(boolean revoked, Optional<OffsetDateTime> expiration, Instant now) {
+    private static String computeFlags(
+            boolean revoked, boolean disabled, Optional<OffsetDateTime> expiration, Instant now) {
         StringBuilder flags = new StringBuilder();
         if (revoked) {
             flags.append('r');
+        }
+        if (disabled) {
+            flags.append('d');
         }
         if (expiration.isPresent() && expiration.get().toInstant().isBefore(now)) {
             flags.append('e');

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
@@ -55,7 +55,12 @@ public class HkpIndexRenderer {
             sb.append('\n');
             for (UidIndexEntry uid : key.verifiedUids()) {
                 sb.append("uid:");
-                sb.append(URLEncoder.encode(uid.uidRaw(), StandardCharsets.UTF_8))
+                // Use %20 for spaces (RFC 3986 percent-encoding) rather than +.
+                // URLEncoder uses application/x-www-form-urlencoded which encodes spaces as '+',
+                // but '+' is a legal literal character in UID strings and would be mis-decoded
+                // by strict HKP clients expecting RFC 3986.
+                sb.append(URLEncoder.encode(uid.uidRaw(), StandardCharsets.UTF_8)
+                                .replace("+", "%20"))
                         .append(':');
                 sb.append(uid.creationTime()
                                 .map(HkpIndexRenderer::toEpochSeconds)

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/LookupEndpoint.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/LookupEndpoint.java
@@ -5,19 +5,21 @@
  */
 package io.github.bmarwell.keyserver.web.pks;
 
+import io.github.bmarwell.keyserver.application.api.KeyIndexResult;
 import io.github.bmarwell.keyserver.application.api.KeyRepositoryService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import java.util.Optional;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 /// HKP `/pks/lookup` endpoint.
 ///
-/// Handles `op=get` (return ASCII-armored key block) and stubs `op=index`/`op=vindex`
-/// (machine-readable listing — future work).
+/// Handles `op=get` (return ASCII-armored key block) and `op=index`
+/// (machine-readable or HTML key listing).
 ///
 /// Only keys with at least one verified UID are returned.  Search by fingerprint
 /// (`0x<hex>`), long/short key ID, email address, or UID substring.
@@ -28,9 +30,15 @@ public class LookupEndpoint {
     @Inject
     KeyRepositoryService keyRepositoryService;
 
+    @Inject
+    HkpIndexRenderer hkpIndexRenderer;
+
     @GET
     public Response doLookup(
-            @QueryParam("op") String op, @QueryParam("search") String search, @QueryParam("exact") String exact) {
+            @QueryParam("op") String op,
+            @QueryParam("search") String search,
+            @QueryParam("exact") String exact,
+            @QueryParam("options") String options) {
 
         // Both null/blank op and search are invalid — HKP requires both to be present.
         // Report exactly which parameter(s) are missing so the client can self-correct.
@@ -50,7 +58,12 @@ public class LookupEndpoint {
             return handleGet(search, exactMatch);
         }
 
-        // op=index and op=vindex are future work
+        if ("index".equalsIgnoreCase(op)) {
+            boolean machineReadable = options != null && options.contains("mr");
+            return handleIndex(search, exactMatch, machineReadable);
+        }
+
+        // op=vindex and unknown ops
         return Response.status(Response.Status.NOT_IMPLEMENTED)
                 .entity("op=" + op + " is not yet implemented")
                 .type("text/plain")
@@ -73,8 +86,29 @@ public class LookupEndpoint {
                 .build();
     }
 
+    private Response handleIndex(String search, boolean exactMatch, boolean machineReadable) {
+        List<KeyIndexResult> results = this.keyRepositoryService.searchForIndex(search, exactMatch);
+        if (results.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("No keys found for the provided search term")
+                    .type("text/plain")
+                    .build();
+        }
+        if (machineReadable) {
+            String body = this.hkpIndexRenderer.renderMachineReadable(results);
+            return Response.ok(body).type("text/plain; charset=utf-8").build();
+        }
+        String body = this.hkpIndexRenderer.renderHtml(results);
+        return Response.ok(body).type("text/html; charset=utf-8").build();
+    }
+
     // CDI-friendly setter for unit testing
     public void setKeyRepositoryService(KeyRepositoryService keyRepositoryService) {
         this.keyRepositoryService = keyRepositoryService;
+    }
+
+    // CDI-friendly setter for unit testing
+    public void setHkpIndexRenderer(HkpIndexRenderer hkpIndexRenderer) {
+        this.hkpIndexRenderer = hkpIndexRenderer;
     }
 }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/LookupEndpoint.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/LookupEndpoint.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -59,7 +60,8 @@ public class LookupEndpoint {
         }
 
         if ("index".equalsIgnoreCase(op)) {
-            boolean machineReadable = options != null && options.contains("mr");
+            boolean machineReadable = options != null
+                    && Arrays.stream(options.split(",")).map(String::strip).anyMatch("mr"::equalsIgnoreCase);
             return handleIndex(search, exactMatch, machineReadable);
         }
 

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/LookupEndpointIndexTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/LookupEndpointIndexTest.java
@@ -99,10 +99,12 @@ class LookupEndpointIndexTest {
         Response response = this.endpoint.doLookup("index", "alice@example.com", null, "mr");
         String body = (String) response.getEntity();
 
-        // then — UID must be percent-encoded so clients can safely parse the colon-delimited format
+        // then — UID must be percent-encoded using %20 for spaces (RFC 3986), not + (form-encoding)
+        // '+' is a legal literal character in UID strings and would be mis-decoded by strict clients
         assertThat(body)
-                .as("UID must be percent-encoded because colons and special chars would break the field delimiter")
-                .contains("uid:Alice+%3Calice%40example.com%3E:");
+                .as("UID must use %20 for spaces, not '+', because '+' is legal in UID strings and"
+                        + " would be mis-decoded by strict RFC 3986 percent-encoding clients")
+                .contains("uid:Alice%20%3Calice%40example.com%3E:");
     }
 
     @Test
@@ -137,10 +139,14 @@ class LookupEndpointIndexTest {
         Response response = this.endpoint.doLookup("index", "alice@example.com", null, "mr");
         String body = (String) response.getEntity();
 
-        // then — the pub: flags field must contain 'e' so GnuPG knows to mark the key as expired
+        // then — the pub: flags field (not just the uid: flags) must contain 'e'
+        // format: pub:<fingerprint>:<algo>:<keylen>:<ctime>:<exptime>:<flags>
+        // Asserting the full pub: line ensures we test the key-level flag specifically,
+        // not just the uid: line which would also show 'e' for the same expiry
         assertThat(body)
-                .as("expired key must have 'e' in flags so GnuPG does not attempt to use it for encryption")
-                .contains(":e\n");
+                .as("expired key must have 'e' in flags on the pub: line so GnuPG knows not to use it for encryption")
+                .contains("pub:" + FINGERPRINT + ":22::" + CREATION.toEpochSecond() + ":" + pastExpiry.toEpochSecond()
+                        + ":e\n");
     }
 
     @Test

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/LookupEndpointIndexTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/LookupEndpointIndexTest.java
@@ -169,6 +169,29 @@ class LookupEndpointIndexTest {
         assertThat(body)
                 .as("HTML body must contain the fingerprint so users can identify the key")
                 .contains(FINGERPRINT);
+        assertThat(body)
+                .as("HTML must include DOCTYPE and charset meta so browsers render it in standards mode with UTF-8")
+                .startsWith("<!DOCTYPE html>");
+        assertThat(body).contains("<meta charset=\"utf-8\">");
+    }
+
+    @Test
+    void recognisesMrTokenAmongCommaDelimitedOptions() {
+        // given — options contains 'mr' alongside another token
+        UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
+        KeyIndexResult key = new KeyIndexResult(
+                FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, false, List.of(uid));
+        this.fakeService.indexResults = List.of(key);
+
+        // when — client sends options=nm,mr (comma-separated list)
+        Response response = this.endpoint.doLookup("index", "alice@example.com", null, "nm,mr");
+        String body = (String) response.getEntity();
+
+        // then — machine-readable format must be returned because 'mr' is in the options list
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(body)
+                .as("'mr' token in a comma-separated options list must trigger machine-readable output")
+                .startsWith("info:1:");
     }
 
     @Test

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/LookupEndpointIndexTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/LookupEndpointIndexTest.java
@@ -53,8 +53,8 @@ class LookupEndpointIndexTest {
     void rendersMachineReadableInfoLineWithKeyCount() {
         // given — one key with one verified UID in the repository
         UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
-        KeyIndexResult key =
-                new KeyIndexResult(FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, List.of(uid));
+        KeyIndexResult key = new KeyIndexResult(
+                FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, false, List.of(uid));
         this.fakeService.indexResults = List.of(key);
 
         // when — the client sends op=index&options=mr (machine-readable)
@@ -72,8 +72,8 @@ class LookupEndpointIndexTest {
     void rendersMachineReadablePubLine() {
         // given — one RSA-2048 key (algorithm 1, bitStrength 2048) with a known creation time
         UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
-        KeyIndexResult key =
-                new KeyIndexResult(FINGERPRINT, 1, Optional.of(2048), CREATION, Optional.empty(), false, List.of(uid));
+        KeyIndexResult key = new KeyIndexResult(
+                FINGERPRINT, 1, Optional.of(2048), CREATION, Optional.empty(), false, false, List.of(uid));
         this.fakeService.indexResults = List.of(key);
 
         // when — client requests machine-readable index
@@ -91,8 +91,8 @@ class LookupEndpointIndexTest {
     void rendersMachineReadableUidLinePercentEncoded() {
         // given — a UID string containing characters that need percent-encoding ('<', '>', ' ')
         UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
-        KeyIndexResult key =
-                new KeyIndexResult(FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, List.of(uid));
+        KeyIndexResult key = new KeyIndexResult(
+                FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, false, List.of(uid));
         this.fakeService.indexResults = List.of(key);
 
         // when — client requests machine-readable index
@@ -111,8 +111,8 @@ class LookupEndpointIndexTest {
     void setsFlagRForRevokedKey() {
         // given — a revoked key without expiration
         UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
-        KeyIndexResult key =
-                new KeyIndexResult(FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), true, List.of(uid));
+        KeyIndexResult key = new KeyIndexResult(
+                FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), true, false, List.of(uid));
         this.fakeService.indexResults = List.of(key);
 
         // when — client requests machine-readable index
@@ -132,7 +132,7 @@ class LookupEndpointIndexTest {
         OffsetDateTime pastExpiry = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.of(pastExpiry), false);
         KeyIndexResult key = new KeyIndexResult(
-                FINGERPRINT, 22, Optional.empty(), CREATION, Optional.of(pastExpiry), false, List.of(uid));
+                FINGERPRINT, 22, Optional.empty(), CREATION, Optional.of(pastExpiry), false, false, List.of(uid));
         this.fakeService.indexResults = List.of(key);
 
         // when — client requests machine-readable index
@@ -153,8 +153,8 @@ class LookupEndpointIndexTest {
     void rendersHtmlWhenOptionsMrAbsent() {
         // given — one key in the repository, no options=mr in the request
         UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
-        KeyIndexResult key =
-                new KeyIndexResult(FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, List.of(uid));
+        KeyIndexResult key = new KeyIndexResult(
+                FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, false, List.of(uid));
         this.fakeService.indexResults = List.of(key);
 
         // when — client sends op=index without options=mr (browser request)
@@ -169,6 +169,25 @@ class LookupEndpointIndexTest {
         assertThat(body)
                 .as("HTML body must contain the fingerprint so users can identify the key")
                 .contains(FINGERPRINT);
+    }
+
+    @Test
+    void setsFlagDForDisabledKey() {
+        // given — a key that has been disabled on this keyserver (not OpenPGP-revoked)
+        UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
+        KeyIndexResult key = new KeyIndexResult(
+                FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, true, List.of(uid));
+        this.fakeService.indexResults = List.of(key);
+
+        // when — client requests machine-readable index
+        Response response = this.endpoint.doLookup("index", "alice@example.com", null, "mr");
+        String body = (String) response.getEntity();
+
+        // then — the pub: flags field must contain 'd' (not 'r') since the key is disabled, not revoked
+        // format: pub:<fingerprint>:<algo>:<keylen>:<ctime>:<exptime>:<flags>
+        assertThat(body)
+                .as("keyserver-disabled key must have 'd' in pub: flags; 'r' is reserved for OpenPGP revocation")
+                .contains("pub:" + FINGERPRINT + ":22::" + CREATION.toEpochSecond() + "::d\n");
     }
 
     // ---------------------------------------------------------------------------

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/LookupEndpointIndexTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/LookupEndpointIndexTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.bmarwell.keyserver.application.api.KeyIndexResult;
+import io.github.bmarwell.keyserver.application.api.KeyRepositoryService;
+import io.github.bmarwell.keyserver.application.api.UidIndexEntry;
+import jakarta.ws.rs.core.Response;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LookupEndpointIndexTest {
+
+    private static final String FINGERPRINT = "A1B2C3D4E5F60708091011121314151617181920A1B2";
+    private static final OffsetDateTime CREATION = OffsetDateTime.of(2024, 1, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+    private static final String UID_RAW = "Alice <alice@example.com>";
+
+    private LookupEndpoint endpoint;
+    private FakeKeyRepositoryService fakeService;
+
+    @BeforeEach
+    void setUp() {
+        this.fakeService = new FakeKeyRepositoryService();
+        this.endpoint = new LookupEndpoint();
+        this.endpoint.setKeyRepositoryService(this.fakeService);
+        this.endpoint.setHkpIndexRenderer(new HkpIndexRenderer());
+    }
+
+    @Test
+    void returnsNotFoundWhenNoKeyMatchesIndexSearch() {
+        // given — the repository contains no keys matching the search
+        this.fakeService.indexResults = List.of();
+
+        // when — the client sends op=index with options=mr
+        Response response = this.endpoint.doLookup("index", "alice@example.com", null, "mr");
+
+        // then — a 404 is returned so GnuPG knows no key was found
+        assertThat(response.getStatus())
+                .as("empty index results must yield 404 so HKP clients know no key was found")
+                .isEqualTo(404);
+    }
+
+    @Test
+    void rendersMachineReadableInfoLineWithKeyCount() {
+        // given — one key with one verified UID in the repository
+        UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
+        KeyIndexResult key =
+                new KeyIndexResult(FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, List.of(uid));
+        this.fakeService.indexResults = List.of(key);
+
+        // when — the client sends op=index&options=mr (machine-readable)
+        Response response = this.endpoint.doLookup("index", "alice@example.com", null, "mr");
+        String body = (String) response.getEntity();
+
+        // then — the info header must contain the key count so GnuPG can allocate result structures
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(body)
+                .as("machine-readable response must start with info:1:<count> per HKP draft spec")
+                .startsWith("info:1:1\n");
+    }
+
+    @Test
+    void rendersMachineReadablePubLine() {
+        // given — one RSA-2048 key (algorithm 1, bitStrength 2048) with a known creation time
+        UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
+        KeyIndexResult key =
+                new KeyIndexResult(FINGERPRINT, 1, Optional.of(2048), CREATION, Optional.empty(), false, List.of(uid));
+        this.fakeService.indexResults = List.of(key);
+
+        // when — client requests machine-readable index
+        Response response = this.endpoint.doLookup("index", "alice@example.com", null, "mr");
+        String body = (String) response.getEntity();
+
+        // then — pub: line must carry fingerprint, algorithm, keylen, epoch seconds, expiry (empty), and flags
+        // The format is required by GnuPG for trust lookups: missing fields break key import
+        assertThat(body)
+                .as("pub line must contain fingerprint and algorithm for GnuPG to import the key")
+                .contains("pub:" + FINGERPRINT + ":1:2048:" + CREATION.toEpochSecond() + "::\n");
+    }
+
+    @Test
+    void rendersMachineReadableUidLinePercentEncoded() {
+        // given — a UID string containing characters that need percent-encoding ('<', '>', ' ')
+        UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
+        KeyIndexResult key =
+                new KeyIndexResult(FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, List.of(uid));
+        this.fakeService.indexResults = List.of(key);
+
+        // when — client requests machine-readable index
+        Response response = this.endpoint.doLookup("index", "alice@example.com", null, "mr");
+        String body = (String) response.getEntity();
+
+        // then — UID must be percent-encoded so clients can safely parse the colon-delimited format
+        assertThat(body)
+                .as("UID must be percent-encoded because colons and special chars would break the field delimiter")
+                .contains("uid:Alice+%3Calice%40example.com%3E:");
+    }
+
+    @Test
+    void setsFlagRForRevokedKey() {
+        // given — a revoked key without expiration
+        UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
+        KeyIndexResult key =
+                new KeyIndexResult(FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), true, List.of(uid));
+        this.fakeService.indexResults = List.of(key);
+
+        // when — client requests machine-readable index
+        Response response = this.endpoint.doLookup("index", "alice@example.com", null, "mr");
+        String body = (String) response.getEntity();
+
+        // then — the pub: flags field must contain 'r' so HKP clients display it as revoked
+        // format: pub:<fingerprint>:<algo>:<keylen>:<ctime>:<exptime>:<flags>
+        assertThat(body)
+                .as("revoked key must have 'r' in flags so HKP clients display it as revoked")
+                .contains("pub:" + FINGERPRINT + ":22::" + CREATION.toEpochSecond() + "::r\n");
+    }
+
+    @Test
+    void setsFlagEForExpiredKey() {
+        // given — a key whose expiration time is clearly in the past (year 2000)
+        OffsetDateTime pastExpiry = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.of(pastExpiry), false);
+        KeyIndexResult key = new KeyIndexResult(
+                FINGERPRINT, 22, Optional.empty(), CREATION, Optional.of(pastExpiry), false, List.of(uid));
+        this.fakeService.indexResults = List.of(key);
+
+        // when — client requests machine-readable index
+        Response response = this.endpoint.doLookup("index", "alice@example.com", null, "mr");
+        String body = (String) response.getEntity();
+
+        // then — the pub: flags field must contain 'e' so GnuPG knows to mark the key as expired
+        assertThat(body)
+                .as("expired key must have 'e' in flags so GnuPG does not attempt to use it for encryption")
+                .contains(":e\n");
+    }
+
+    @Test
+    void rendersHtmlWhenOptionsMrAbsent() {
+        // given — one key in the repository, no options=mr in the request
+        UidIndexEntry uid = new UidIndexEntry(UID_RAW, Optional.of(CREATION), Optional.empty(), false);
+        KeyIndexResult key =
+                new KeyIndexResult(FINGERPRINT, 22, Optional.empty(), CREATION, Optional.empty(), false, List.of(uid));
+        this.fakeService.indexResults = List.of(key);
+
+        // when — client sends op=index without options=mr (browser request)
+        Response response = this.endpoint.doLookup("index", "alice@example.com", null, null);
+        String body = (String) response.getEntity();
+
+        // then — response must be HTML so it can be displayed in a browser for human inspection
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type"))
+                .as("browser requests (no options=mr) must receive HTML for human readability")
+                .startsWith("text/html");
+        assertThat(body)
+                .as("HTML body must contain the fingerprint so users can identify the key")
+                .contains(FINGERPRINT);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test double — avoids CDI/Mockito overhead; keeps the test focused on the
+    // endpoint's routing and response-building logic only
+    // ---------------------------------------------------------------------------
+
+    private static final class FakeKeyRepositoryService implements KeyRepositoryService {
+
+        List<KeyIndexResult> indexResults = List.of();
+
+        @Override
+        public Optional<String> getArmoredKeyBySearch(String search, boolean exactMatch) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<KeyIndexResult> searchForIndex(String search, boolean exactMatch) {
+            return this.indexResults;
+        }
+
+        @Override
+        public void getKeyByRepoAndKeyId(
+                io.github.bmarwell.keyserver.common.ids.RepositoryName repoName,
+                io.github.bmarwell.keyserver.common.ids.KeyId keyId) {
+            throw new UnsupportedOperationException("not needed in this test");
+        }
+
+        @Override
+        public Optional<io.github.bmarwell.keyserver.common.ids.PgpPublicKey> getKeyByKeyId(
+                io.github.bmarwell.keyserver.common.ids.KeyId keyId) {
+            return Optional.empty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements `GET /pks/lookup?op=index` as described in #137.

### What changed

**Architecture:**
- `KeyIndexResult` and `UidIndexEntry` are top-level records in `application-api` — the web layer only depends on primary ports, no secondary port types cross the boundary
- Added `@NullMarked` `package-info.java` to the `application.api` root package
- `application-port-repository` pom gains a dependency on `application-api` (one-way, no cycle)

**Port layer (`KeyRepository`):**
- Added `findManyBySearch(String, boolean)` returning `List<KeyIndexResult>`

**Service layer:**
- `KeyRepositoryService.searchForIndex()` delegates to the new port method
- `PersistentKeyRepositoryService` implements it

**Repository adapter (`JpaKeyRepository`):**
- `findManyBySearch()` with the same routing (fingerprint → email → UID substring)
- Extracted `queryEntitiesByEmail()` and `queryEntitiesByUidSubstring()` helpers that both the single-result and multi-result paths share — eliminates duplicated JPQL
- `toIndexResult(KeyEntity)` maps to the new record; only `verified=true` UIDs included

**Web layer:**
- `HkpIndexRenderer` (ApplicationScoped): `renderMachineReadable()` produces the HKP `info:/pub:/uid:` format; `renderHtml()` a simple table
- `LookupEndpoint` routes `op=index`: `options=mr` → `text/plain`, else `text/html`; returns 404 when no results

**Tests (`LookupEndpointIndexTest`, 7 cases):**
- 404 on empty results
- `info:1:` header with correct count
- `pub:` line format (fingerprint, algorithm, keylen, epoch seconds)
- UID percent-encoding
- `r` flag for revoked keys
- `e` flag for expired keys
- HTML content-type and fingerprint presence for non-mr requests

Closes #137