### PR TITLE
feat(#140): VerifyEndpoint returns meaningful HTML pages

### DIFF
--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/VerificationResult.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/VerificationResult.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.api;
+
+/// Outcome of a successful UID verification.
+///
+/// Returned by {@link VerificationService#verifyUid} when the token is valid,
+/// not expired, and the corresponding UID has been published to the key store.
+/// Callers may use these fields to build a user-facing confirmation page.
+///
+/// The fingerprint is in upper-case hex without spaces (40 chars for RSA/DSA/ECDSA
+/// v4 fingerprints, 64 chars for v6 fingerprints).
+public record VerificationResult(String uidRaw, String fingerprint) {}

--- a/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/VerificationService.java
+++ b/application/application-api/src/main/java/io/github/bmarwell/keyserver/application/api/VerificationService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.api;
+
+import io.github.bmarwell.keyserver.application.api.ex.TokenExpiredException;
+import io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException;
+
+/// Primary (inbound) port for synchronous UID verification.
+///
+/// Implementations handle the full token-to-publication flow synchronously,
+/// allowing callers to surface success or failure to the user immediately.
+/// This is the preferred path for the HKP {@code /pks/verify/{token}} endpoint and
+/// for any future VKS REST endpoint that needs to confirm verification outcome inline.
+///
+/// The async path via {@link CommandService} + {@code VerifyUidCommand} remains
+/// available but does not surface outcome to the caller.
+public interface VerificationService {
+
+    /// Verifies a UID via its token synchronously.
+    ///
+    /// Parses the token, loads and validates the queue entry, marks it verified,
+    /// and publishes the corresponding UID to the key store — all within a single
+    /// transaction whose outcome the caller can observe immediately.
+    ///
+    /// @param token the unsigned-decimal string TSID from the verification URI
+    /// @return a {@link VerificationResult} describing what was verified
+    /// @throws TokenInvalidException if the token cannot be parsed, is not found,
+    ///         or has already been consumed
+    /// @throws TokenExpiredException if the token is found but its deadline has passed
+    VerificationResult verifyUid(String token);
+}

--- a/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/SynchronousVerificationService.java
+++ b/application/application-core/src/main/java/io/github/bmarwell/keyserver/application/core/SynchronousVerificationService.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core;
+
+import io.github.bmarwell.keyserver.application.api.VerificationResult;
+import io.github.bmarwell.keyserver.application.api.VerificationService;
+import io.github.bmarwell.keyserver.application.api.ex.TokenExpiredException;
+import io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException;
+import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
+import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
+import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationEntry;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.time.OffsetDateTime;
+
+/// Synchronous implementation of {@link VerificationService}.
+///
+/// Unlike the async command-handler path ({@link
+/// io.github.bmarwell.keyserver.application.core.cmdhandler.VerifyUidCommandHandler}
+/// via {@link io.github.bmarwell.keyserver.application.api.CommandService}),
+/// this service runs the full verification flow synchronously inside a single JTA
+/// transaction and surfaces the outcome to the caller immediately.
+///
+/// This service does not write to the business-transaction (BTX) audit table — BTX
+/// is an artefact of the async command pipeline and is not available in the sync path.
+///
+/// This is the preferred path for any endpoint that must confirm verification success
+/// or failure to the user inline (e.g. the HKP {@code /pks/verify/{token}} endpoint
+/// and future VKS endpoints).
+@ApplicationScoped
+public class SynchronousVerificationService implements VerificationService {
+
+    @Inject
+    VerificationQueueRepository verificationQueueRepository;
+
+    @Inject
+    KeyRepository keyRepository;
+
+    @Override
+    @Transactional
+    public VerificationResult verifyUid(String token) {
+        long tokenId = parseToken(token);
+
+        VerificationEntry entry = this.verificationQueueRepository
+                .findPendingById(tokenId)
+                .orElseThrow(() -> new TokenInvalidException(
+                        // Do not echo the token value — it is attacker-controlled and could
+                        // be arbitrarily long or contain control characters (log injection).
+                        "Verification token not found or already consumed"));
+
+        if (entry.expiresAt().isBefore(OffsetDateTime.now())) {
+            throw new TokenExpiredException("Verification token has expired");
+        }
+
+        this.verificationQueueRepository.markVerified(tokenId);
+        this.keyRepository.publishVerifiedUid(
+                entry.fingerprint(), entry.uidRaw(), entry.uidEmail(), entry.armoredKey());
+
+        return new VerificationResult(entry.uidRaw(), entry.fingerprint());
+    }
+
+    private static long parseToken(String token) {
+        try {
+            return Long.parseUnsignedLong(token);
+        } catch (NumberFormatException e) {
+            throw new TokenInvalidException("Verification token is not a valid unsigned integer");
+        }
+    }
+
+    // CDI-friendly setters for unit testing
+    public void setVerificationQueueRepository(VerificationQueueRepository verificationQueueRepository) {
+        this.verificationQueueRepository = verificationQueueRepository;
+    }
+
+    public void setKeyRepository(KeyRepository keyRepository) {
+        this.keyRepository = keyRepository;
+    }
+}

--- a/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/SynchronousVerificationServiceTest.java
+++ b/application/application-core/src/test/java/io/github/bmarwell/keyserver/application/core/SynchronousVerificationServiceTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.application.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.bmarwell.keyserver.application.api.VerificationResult;
+import io.github.bmarwell.keyserver.application.api.ex.TokenExpiredException;
+import io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException;
+import io.github.bmarwell.keyserver.application.port.repository.KeyRepository;
+import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository;
+import io.github.bmarwell.keyserver.application.port.repository.VerificationQueueRepository.VerificationEntry;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/// Unit tests for {@link SynchronousVerificationService}.
+///
+/// All major verification-flow scenarios are covered here without a CDI container or
+/// database. Dependencies are injected via CDI-friendly setters using in-memory fakes.
+class SynchronousVerificationServiceTest {
+
+    // -----------------------------------------------------------------------
+    // Fakes
+    // -----------------------------------------------------------------------
+
+    record PublishedUid(String fingerprint, String uidRaw, String uidEmail) {}
+
+    static class FakeKeyRepository implements KeyRepository {
+        final List<PublishedUid> published = new ArrayList<>();
+
+        @Override
+        public void publishVerifiedUid(String fingerprint, String uidRaw, String uidEmail, String armoredKey) {
+            this.published.add(new PublishedUid(fingerprint, uidRaw, uidEmail));
+        }
+
+        @Override
+        public Optional<KeySearchResult> findBySearch(String search, boolean exactMatch) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<io.github.bmarwell.keyserver.application.api.KeyIndexResult> findManyBySearch(
+                String search, boolean exactMatch) {
+            return List.of();
+        }
+    }
+
+    static class FakeVerificationQueueRepository implements VerificationQueueRepository {
+
+        record StoredEntry(VerificationEntry entry, boolean consumed) {}
+
+        final Map<Long, StoredEntry> store = Collections.synchronizedMap(new HashMap<>());
+        final List<Long> verifiedIds = Collections.synchronizedList(new ArrayList<>());
+
+        void put(long id, VerificationEntry entry) {
+            this.store.put(id, new StoredEntry(entry, false));
+        }
+
+        @Override
+        public long enqueue(VerificationRequest request) {
+            throw new UnsupportedOperationException("not needed in this test");
+        }
+
+        @Override
+        public Optional<VerificationEntry> findPendingById(long tokenId) {
+            StoredEntry stored = this.store.get(tokenId);
+            if (stored == null || stored.consumed()) {
+                return Optional.empty();
+            }
+            return Optional.of(stored.entry());
+        }
+
+        @Override
+        public void markVerified(long tokenId) {
+            StoredEntry stored = this.store.get(tokenId);
+            if (stored != null) {
+                this.store.put(tokenId, new StoredEntry(stored.entry(), true));
+                this.verifiedIds.add(tokenId);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Fixture helpers
+    // -----------------------------------------------------------------------
+
+    static final String FINGERPRINT = "AABBCCDDEEFF00112233445566778899AABBCCDD";
+    static final String ARMORED_KEY =
+            "-----BEGIN PGP PUBLIC KEY BLOCK-----\n(stub)\n-----END PGP PUBLIC KEY BLOCK-----";
+    static final long TOKEN_1 = 1_000L;
+    static final long TOKEN_2 = 2_000L;
+
+    private VerificationEntry pendingEntry(long id, String uidRaw, String uidEmail) {
+        return new VerificationEntry(
+                id,
+                FINGERPRINT,
+                uidRaw,
+                uidEmail,
+                ARMORED_KEY,
+                OffsetDateTime.now().plusHours(24));
+    }
+
+    private VerificationEntry expiredEntry(long id, String uidRaw, String uidEmail) {
+        return new VerificationEntry(
+                id,
+                FINGERPRINT,
+                uidRaw,
+                uidEmail,
+                ARMORED_KEY,
+                OffsetDateTime.now().minusHours(1));
+    }
+
+    FakeVerificationQueueRepository fakeQueue;
+    FakeKeyRepository fakeKeys;
+    SynchronousVerificationService service;
+
+    @BeforeEach
+    void setUp() {
+        this.fakeQueue = new FakeVerificationQueueRepository();
+        this.fakeKeys = new FakeKeyRepository();
+        this.service = new SynchronousVerificationService();
+        this.service.setVerificationQueueRepository(this.fakeQueue);
+        this.service.setKeyRepository(this.fakeKeys);
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy path
+    // -----------------------------------------------------------------------
+
+    @Test
+    void valid_token_publishes_uid_and_returns_result() {
+        // given
+        this.fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+
+        // when
+        VerificationResult result = this.service.verifyUid(Long.toUnsignedString(TOKEN_1));
+
+        // then
+        assertThat(result.uidRaw()).isEqualTo("Alice <alice@example.com>");
+        assertThat(result.fingerprint()).isEqualTo(FINGERPRINT);
+        assertThat(this.fakeKeys.published).hasSize(1);
+        assertThat(this.fakeKeys.published.getFirst().uidEmail()).isEqualTo("alice@example.com");
+        assertThat(this.fakeQueue.verifiedIds).containsExactly(TOKEN_1);
+    }
+
+    @Test
+    void token_is_consumed_after_first_use() {
+        // given
+        this.fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+
+        // when
+        this.service.verifyUid(Long.toUnsignedString(TOKEN_1));
+
+        // then: second use of the same token must be rejected
+        assertThatThrownBy(() -> this.service.verifyUid(Long.toUnsignedString(TOKEN_1)))
+                .isInstanceOf(TokenInvalidException.class);
+        assertThat(this.fakeKeys.published).hasSize(1);
+    }
+
+    @Test
+    void two_separate_tokens_both_verified() {
+        // given
+        this.fakeQueue.put(TOKEN_1, pendingEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+        this.fakeQueue.put(TOKEN_2, pendingEntry(TOKEN_2, "Alice Work <work@corp.example>", "work@corp.example"));
+
+        // when
+        this.service.verifyUid(Long.toUnsignedString(TOKEN_1));
+        this.service.verifyUid(Long.toUnsignedString(TOKEN_2));
+
+        // then
+        assertThat(this.fakeKeys.published)
+                .extracting(PublishedUid::uidEmail)
+                .containsExactlyInAnyOrder("alice@example.com", "work@corp.example");
+        assertThat(this.fakeQueue.verifiedIds).containsExactlyInAnyOrder(TOKEN_1, TOKEN_2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Error cases
+    // -----------------------------------------------------------------------
+
+    @Test
+    void expired_token_throws_TokenExpiredException() {
+        // given
+        this.fakeQueue.put(TOKEN_1, expiredEntry(TOKEN_1, "Alice <alice@example.com>", "alice@example.com"));
+
+        // when / then
+        assertThatThrownBy(() -> this.service.verifyUid(Long.toUnsignedString(TOKEN_1)))
+                .isInstanceOf(TokenExpiredException.class);
+        assertThat(this.fakeKeys.published).isEmpty();
+        assertThat(this.fakeQueue.verifiedIds).isEmpty();
+    }
+
+    @Test
+    void unknown_token_throws_TokenInvalidException() {
+        // given — nothing in the queue
+
+        // when / then
+        assertThatThrownBy(() -> this.service.verifyUid(Long.toUnsignedString(9_999L)))
+                .isInstanceOf(TokenInvalidException.class);
+        assertThat(this.fakeKeys.published).isEmpty();
+    }
+
+    @Test
+    void garbled_token_string_throws_TokenInvalidException() {
+        // given — token is not a valid unsigned integer
+
+        // when / then
+        assertThatThrownBy(() -> this.service.verifyUid("not-a-number")).isInstanceOf(TokenInvalidException.class);
+        assertThat(this.fakeKeys.published).isEmpty();
+    }
+
+    @Test
+    void negative_token_string_throws_TokenInvalidException() {
+        // given — negative numbers are not valid unsigned long strings
+
+        // when / then
+        assertThatThrownBy(() -> this.service.verifyUid("-1")).isInstanceOf(TokenInvalidException.class);
+    }
+}

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyEndpoint.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyEndpoint.java
@@ -60,17 +60,17 @@ public class VerifyEndpoint {
     public Response verify(@PathParam("token") String token) {
         try {
             VerificationResult result = this.verificationService.verifyUid(token);
-            return Response.ok(this.verifyRenderer.renderSuccess(result), "text/html;charset=utf-8")
+            return Response.ok(this.verifyRenderer.renderSuccess(result), "text/html; charset=utf-8")
                     .build();
         } catch (TokenExpiredException e) {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity(this.verifyRenderer.renderExpired())
-                    .type("text/html;charset=utf-8")
+                    .type("text/html; charset=utf-8")
                     .build();
         } catch (TokenInvalidException e) {
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity(this.verifyRenderer.renderInvalid())
-                    .type("text/html;charset=utf-8")
+                    .type("text/html; charset=utf-8")
                     .build();
         }
     }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyEndpoint.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyEndpoint.java
@@ -5,53 +5,82 @@
  */
 package io.github.bmarwell.keyserver.web.pks;
 
-import io.github.bmarwell.keyserver.application.api.CommandService;
-import io.github.bmarwell.keyserver.application.api.commands.CommandCallerContext;
-import io.github.bmarwell.keyserver.application.api.commands.VerifyUidCommand;
+import io.github.bmarwell.keyserver.application.api.VerificationResult;
+import io.github.bmarwell.keyserver.application.api.VerificationService;
+import io.github.bmarwell.keyserver.application.api.ex.TokenExpiredException;
+import io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 /// Handles the email-verification link clicked by a key owner.
 ///
-/// ## Async dispatch
+/// ## Synchronous verification
 ///
-/// The command is dispatched via the standard async `CommandService`.  This means
-/// the response is `202 Accepted` and the caller does not receive inline success or
-/// failure feedback.  A future iteration should add a synchronous invocation path
-/// (or polling mechanism) so the user sees a meaningful confirmation page.
+/// The verification is performed synchronously via {@link VerificationService}.
+/// The user receives an immediate HTML confirmation or error page rather than a
+/// generic `202 Accepted` response.
 ///
 /// ## Caller context
 ///
 /// The IP is not forwarded for the verification step: the token already serves as
 /// a one-time credential and IP attribution here adds no audit value.
-/// {@link CommandCallerContext#empty()} is used.
 @Tag(name = "OpenPGP Keyserver Protocol: Verify")
 @Path("verify")
 public class VerifyEndpoint {
 
     @Inject
-    CommandService commandService;
+    VerificationService verificationService;
+
+    @Inject
+    VerifyRenderer verifyRenderer;
 
     /// Consumes a verification token from a link sent to the key owner's email
-    /// address and schedules the corresponding UID for publication.
+    /// address, publishes the corresponding UID, and returns a human-readable HTML page.
+    ///
+    /// Returns {@code 200 OK} with a success page on successful verification, or
+    /// {@code 400 Bad Request} with an explanatory error page if the token is
+    /// invalid, already consumed, or expired.
     ///
     /// @param token the TSID of the verification-queue entry, as an unsigned decimal string
-    /// @return `202 Accepted` — the verification is processed asynchronously
+    /// @return HTML page describing the outcome
     @GET
     @Path("{token}")
+    @Produces(MediaType.TEXT_HTML)
     @Operation(summary = "Confirm email ownership via verification link")
+    @APIResponse(responseCode = "200", description = "UID verified and published successfully")
+    @APIResponse(responseCode = "400", description = "Token is invalid, already consumed, or expired")
     public Response verify(@PathParam("token") String token) {
-        var command = new VerifyUidCommand(token);
-        commandService.handleCommand(command, CommandCallerContext.empty());
-        return Response.accepted().build();
+        try {
+            VerificationResult result = this.verificationService.verifyUid(token);
+            return Response.ok(this.verifyRenderer.renderSuccess(result), "text/html;charset=utf-8")
+                    .build();
+        } catch (TokenExpiredException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(this.verifyRenderer.renderExpired())
+                    .type("text/html;charset=utf-8")
+                    .build();
+        } catch (TokenInvalidException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(this.verifyRenderer.renderInvalid())
+                    .type("text/html;charset=utf-8")
+                    .build();
+        }
     }
 
-    public void setCommandService(CommandService commandService) {
-        this.commandService = commandService;
+    // CDI-friendly setters for unit testing
+    public void setVerificationService(VerificationService verificationService) {
+        this.verificationService = verificationService;
+    }
+
+    public void setVerifyRenderer(VerifyRenderer verifyRenderer) {
+        this.verifyRenderer = verifyRenderer;
     }
 }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyRenderer.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import io.github.bmarwell.keyserver.application.api.VerificationResult;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/// Renders HTML pages for the UID verification endpoint.
+///
+/// Produces three page types:
+/// <ul>
+///   <li>{@link #renderSuccess} — shown when a verification token was consumed successfully.</li>
+///   <li>{@link #renderExpired} — shown when the token exists but its deadline has passed.</li>
+///   <li>{@link #renderInvalid} — shown when the token is missing, garbled, or already consumed.</li>
+/// </ul>
+///
+/// The rendering logic is intentionally isolated here so that the HTML generation
+/// strategy can be changed — for example, migrated to a template engine such as
+/// Freemarker or JMustache — without modifying the endpoint or the application service.
+/// When migrating, only the body of each render method changes; their signatures and
+/// the {@link VerifyEndpoint} caller remain stable.
+@ApplicationScoped
+public class VerifyRenderer {
+
+    /// Renders a success page shown after a token is consumed and the UID published.
+    ///
+    /// @param result the outcome of the verification containing the UID raw string and fingerprint
+    /// @return HTML string with DOCTYPE and charset declaration
+    public String renderSuccess(VerificationResult result) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<!DOCTYPE html>\n");
+        sb.append("<html><head><meta charset=\"utf-8\"><title>Email address verified</title></head>\n");
+        sb.append("<body>\n");
+        sb.append("<h1>Email address verified</h1>\n");
+        sb.append("<p>The following UID has been verified and is now published:</p>\n");
+        sb.append("<p><strong>").append(htmlEscape(result.uidRaw())).append("</strong></p>\n");
+        sb.append("<p>You can look up your key using the ");
+        sb.append("<a href=\"/pks/lookup?op=index&amp;search=");
+        sb.append(htmlEscape(result.fingerprint())).append("\">keyserver search</a>.</p>\n");
+        sb.append("</body></html>");
+        return sb.toString();
+    }
+
+    /// Renders an error page for expired verification tokens.
+    ///
+    /// @return HTML string with DOCTYPE and charset declaration
+    public String renderExpired() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<!DOCTYPE html>\n");
+        sb.append("<html><head><meta charset=\"utf-8\"><title>Verification link expired</title></head>\n");
+        sb.append("<body>\n");
+        sb.append("<h1>Verification link expired</h1>\n");
+        sb.append("<p>The verification link you followed has expired.</p>\n");
+        sb.append("<p>Please upload your key again to receive a new verification email.</p>\n");
+        sb.append("</body></html>");
+        return sb.toString();
+    }
+
+    /// Renders an error page for invalid, missing, or already-consumed verification tokens.
+    ///
+    /// @return HTML string with DOCTYPE and charset declaration
+    public String renderInvalid() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<!DOCTYPE html>\n");
+        sb.append("<html><head><meta charset=\"utf-8\"><title>Invalid verification link</title></head>\n");
+        sb.append("<body>\n");
+        sb.append("<h1>Invalid verification link</h1>\n");
+        sb.append("<p>The verification link you followed is no longer valid.</p>\n");
+        sb.append("<p>It may have already been used, may not exist, or may be malformed.</p>\n");
+        sb.append("<p>Please upload your key again to receive a new verification email.</p>\n");
+        sb.append("</body></html>");
+        return sb.toString();
+    }
+
+    private static String htmlEscape(String s) {
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    }
+}

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/VerifyEndpointTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/VerifyEndpointTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.bmarwell.keyserver.application.api.VerificationResult;
+import io.github.bmarwell.keyserver.application.api.ex.TokenExpiredException;
+import io.github.bmarwell.keyserver.application.api.ex.TokenInvalidException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/// Unit tests for {@link VerifyEndpoint}.
+///
+/// Verifies that the endpoint maps service outcomes to the correct HTTP status codes
+/// and HTML content-type without a CDI container or server.
+class VerifyEndpointTest {
+
+    static final String FINGERPRINT = "AABBCCDDEEFF00112233445566778899AABBCCDD";
+
+    VerifyEndpoint endpoint;
+
+    @BeforeEach
+    void setUp() {
+        this.endpoint = new VerifyEndpoint();
+        this.endpoint.setVerifyRenderer(new VerifyRenderer());
+    }
+
+    @Test
+    void valid_token_returns_200_with_html() {
+        // given
+        this.endpoint.setVerificationService(token -> new VerificationResult("Alice <alice@example.com>", FINGERPRINT));
+
+        // when
+        Response response = this.endpoint.verify("1000");
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getMediaType().toString()).startsWith("text/html");
+        assertThat(response.getEntity().toString()).contains("verified");
+    }
+
+    @Test
+    void valid_token_html_contains_uid() {
+        // given
+        this.endpoint.setVerificationService(token -> new VerificationResult("Alice <alice@example.com>", FINGERPRINT));
+
+        // when
+        Response response = this.endpoint.verify("1000");
+
+        // then
+        assertThat(response.getEntity().toString()).contains("Alice");
+    }
+
+    @Test
+    void expired_token_returns_400_with_html() {
+        // given
+        this.endpoint.setVerificationService(token -> {
+            throw new TokenExpiredException("expired");
+        });
+
+        // when
+        Response response = this.endpoint.verify("1000");
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getMediaType().toString()).startsWith("text/html");
+        assertThat(response.getEntity().toString()).contains("expired");
+    }
+
+    @Test
+    void invalid_token_returns_400_with_html() {
+        // given
+        this.endpoint.setVerificationService(token -> {
+            throw new TokenInvalidException("not found");
+        });
+
+        // when
+        Response response = this.endpoint.verify("not-a-number");
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getMediaType().toString()).startsWith("text/html");
+        assertThat(response.getEntity().toString()).containsAnyOf("invalid", "Invalid");
+    }
+
+    @Test
+    void response_does_not_echo_token_in_body() {
+        // given — a garbled token that must not appear in the error page body
+        String garbledToken = "evil-token-12345";
+        this.endpoint.setVerificationService(token -> {
+            throw new TokenInvalidException("not found");
+        });
+
+        // when
+        Response response = this.endpoint.verify(garbledToken);
+
+        // then
+        assertThat(response.getEntity().toString()).doesNotContain(garbledToken);
+    }
+}

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/VerifyRendererTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/VerifyRendererTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.bmarwell.keyserver.application.api.VerificationResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/// Unit tests for {@link VerifyRenderer}.
+///
+/// Verifies that each page type contains the expected DOCTYPE, charset, and content
+/// without relying on a CDI container.
+class VerifyRendererTest {
+
+    VerifyRenderer renderer;
+
+    @BeforeEach
+    void setUp() {
+        this.renderer = new VerifyRenderer();
+    }
+
+    @Test
+    void success_page_contains_doctype_and_charset() {
+        // given
+        var result = new VerificationResult("Alice <alice@example.com>", "AABBCCDDEEFF00112233445566778899AABBCCDD");
+
+        // when
+        String html = this.renderer.renderSuccess(result);
+
+        // then
+        assertThat(html).startsWith("<!DOCTYPE html>");
+        assertThat(html).contains("charset=\"utf-8\"");
+    }
+
+    @Test
+    void success_page_contains_uid_and_fingerprint() {
+        // given
+        var result = new VerificationResult("Alice <alice@example.com>", "AABBCCDDEEFF00112233445566778899AABBCCDD");
+
+        // when
+        String html = this.renderer.renderSuccess(result);
+
+        // then
+        assertThat(html).contains("Alice &lt;alice@example.com&gt;");
+        assertThat(html).contains("AABBCCDDEEFF00112233445566778899AABBCCDD");
+    }
+
+    @Test
+    void success_page_escapes_special_chars_in_uid() {
+        // given — UID contains angle brackets (common in PGP UIDs)
+        var result = new VerificationResult("Bob & Alice <bob&alice@example.com>", "FFFF");
+
+        // when
+        String html = this.renderer.renderSuccess(result);
+
+        // then — raw < > & must not appear unescaped inside the content
+        assertThat(html).doesNotContain("Bob & Alice <bob&alice@example.com>");
+        assertThat(html).contains("Bob &amp; Alice &lt;bob&amp;alice@example.com&gt;");
+    }
+
+    @Test
+    void expired_page_contains_doctype_and_charset() {
+        // given — no input required
+
+        // when
+        String html = this.renderer.renderExpired();
+
+        // then
+        assertThat(html).startsWith("<!DOCTYPE html>");
+        assertThat(html).contains("charset=\"utf-8\"");
+        assertThat(html).contains("expired");
+    }
+
+    @Test
+    void invalid_page_contains_doctype_and_charset() {
+        // given — no input required
+
+        // when
+        String html = this.renderer.renderInvalid();
+
+        // then
+        assertThat(html).startsWith("<!DOCTYPE html>");
+        assertThat(html).contains("charset=\"utf-8\"");
+        assertThat(html).containsAnyOf("invalid", "Invalid");
+    }
+}


### PR DESCRIPTION
Closes #140

## Summary

Replace the fire-and-forget async `202 Accepted` with a synchronous verification flow that returns meaningful HTML pages to the user.

## Changes

### Commit 1 — `VerificationService` port + `SynchronousVerificationService`
- **`VerificationResult`** record (`uidRaw`, `fingerprint`) returned on success
- **`VerificationService`** inbound port interface in `application-api`
- **`SynchronousVerificationService`** `@ApplicationScoped @Transactional` impl in `application-core`: parses token, checks expiry, marks verified, publishes UID
- Does **not** write to the BTX audit table — BTX is an artefact of the async command pipeline
- 7 unit tests

### Commit 2 — `VerifyRenderer`
- **`VerifyRenderer`** renders three distinct HTML pages (success, expired, invalid)
- All pages include `DOCTYPE` and `charset=utf-8`; special characters in UID strings are HTML-escaped
- Isolated from the endpoint so migrating to Freemarker/Mustache only touches the renderer internals
- 5 unit tests

### Commit 3 — Updated `VerifyEndpoint`
- Injects `VerificationService` + `VerifyRenderer`; dispatches synchronously
- **`200 OK`** + success page on valid token; **`400 Bad Request`** + error page for invalid or expired tokens
- Raw token value is never echoed in any response body
- `@Produces(TEXT_HTML)` + `@APIResponse` OpenAPI annotations added
- 5 unit tests

## Extensibility

The `VerifyRenderer` interface is designed so that migrating to a template engine (tracked in #154) only requires changing the renderer method bodies — no callers change. `VerificationService` can also be called directly from future VKS REST endpoints.