### PR TITLE
feat(#154): migrate HTML rendering to Freemarker templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <immutables-value.version>2.10.0</immutables-value.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <hypersistence-tsid.version>2.1.4</hypersistence-tsid.version>
+    <freemarker.version>2.3.34</freemarker.version>
 
     <!-- plugin dependencies -->
     <palantir-java-format.version>2.91.0</palantir-java-format.version>
@@ -158,6 +159,12 @@
         <artifactId>flyway-database-postgresql</artifactId>
         <version>${flyway.version}</version>
         <scope>runtime</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.freemarker</groupId>
+        <artifactId>freemarker</artifactId>
+        <version>${freemarker.version}</version>
       </dependency>
 
       <dependency>

--- a/web/openpgp-keyserver-protocol/pom.xml
+++ b/web/openpgp-keyserver-protocol/pom.xml
@@ -60,6 +60,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.freemarker</groupId>
+      <artifactId>freemarker</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.github.bmarwell.keyserver</groupId>
       <artifactId>keyserver-application-api</artifactId>
       <version>0.1.0-SNAPSHOT</version>

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/AbstractFreemarkerRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/AbstractFreemarkerRenderer.java
@@ -30,7 +30,9 @@ abstract class AbstractFreemarkerRenderer {
     ///                     (e.g. {@code "verify-success.ftlh"})
     /// @param model        variables made available inside the template
     /// @return rendered output as a string
-    /// @throws IllegalStateException if the template cannot be found or rendering fails
+    /// @throws TemplateRenderingException if the template cannot be found or rendering fails;
+    ///         caught by {@link TemplateRenderingExceptionMapper}, which logs the detail and
+    ///         returns a 500 response
     protected String processTemplate(String templateName, Map<String, Object> model) {
         try {
             Template template = this.configuration.getTemplate(templateName);
@@ -38,7 +40,7 @@ abstract class AbstractFreemarkerRenderer {
             template.process(model, writer);
             return writer.toString();
         } catch (Exception e) {
-            throw new IllegalStateException("Failed to render template: " + templateName, e);
+            throw new TemplateRenderingException(templateName, e);
         }
     }
 

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/AbstractFreemarkerRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/AbstractFreemarkerRenderer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import jakarta.inject.Inject;
+import java.io.StringWriter;
+import java.util.Map;
+
+/// Base class for Freemarker-backed renderers.
+///
+/// Holds the shared {@link Configuration} injection, the {@link #processTemplate} helper,
+/// and the CDI-friendly setter used to wire the configuration in unit tests without a
+/// CDI container.
+///
+/// Subclasses are responsible only for building the template model and choosing the
+/// template name; all template loading and rendering is handled here.
+abstract class AbstractFreemarkerRenderer {
+
+    @Inject
+    Configuration configuration;
+
+    /// Loads and processes a Freemarker template, returning the rendered string.
+    ///
+    /// @param templateName filename relative to the {@code /templates/} classpath root
+    ///                     (e.g. {@code "verify-success.ftlh"})
+    /// @param model        variables made available inside the template
+    /// @return rendered output as a string
+    /// @throws IllegalStateException if the template cannot be found or rendering fails
+    protected String processTemplate(String templateName, Map<String, Object> model) {
+        try {
+            Template template = this.configuration.getTemplate(templateName);
+            StringWriter writer = new StringWriter();
+            template.process(model, writer);
+            return writer.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to render template: " + templateName, e);
+        }
+    }
+
+    /// CDI-friendly setter; allows unit tests to inject a {@link Configuration} instance
+    /// without spinning up a CDI container.
+    public void setConfiguration(Configuration configuration) {
+        this.configuration = configuration;
+    }
+}

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/FreemarkerConfiguration.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/FreemarkerConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.core.HTMLOutputFormat;
+import freemarker.core.PlainTextOutputFormat;
+import freemarker.template.Configuration;
+import freemarker.template.TemplateExceptionHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+/// CDI producer for the singleton Freemarker {@link Configuration}.
+///
+/// A single {@link Configuration} instance is safe to share across all threads once
+/// built; Freemarker's own documentation mandates exactly this pattern.
+///
+/// Template loading strategy:
+/// <ul>
+///   <li>Templates are loaded from the classpath under {@code /templates/}.
+///       Placing them in {@code src/main/resources/templates/} ensures they are
+///       packaged inside the WAR's {@code WEB-INF/classes/templates/} directory.</li>
+///   <li>{@code .ftlh} files (used for HTML pages) have auto-escaping enabled via
+///       {@link HTMLOutputFormat} so raw user-supplied strings cannot inject HTML.</li>
+///   <li>{@code .ftl} files (used for machine-readable HKP output) use
+///       {@link PlainTextOutputFormat} — no escaping is applied, and the Java layer
+///       must pre-encode all values before passing them to the model.</li>
+/// </ul>
+///
+/// Exceptions thrown during template processing propagate as {@link RuntimeException}
+/// (via {@link TemplateExceptionHandler#RETHROW_HANDLER}), which JAX-RS maps to a
+/// 500 response via the existing {@link KeyServerExceptionMapper}.
+@ApplicationScoped
+public class FreemarkerConfiguration {
+
+    /// Produces the shared Freemarker {@link Configuration}.
+    ///
+    /// @return configured and ready-to-use Freemarker configuration
+    @Produces
+    @ApplicationScoped
+    public Configuration freemarkerConfiguration() {
+        Configuration cfg = new Configuration(Configuration.VERSION_2_3_34);
+        cfg.setTemplateLoader(new ClassTemplateLoader(FreemarkerConfiguration.class, "/templates/"));
+        cfg.setDefaultEncoding("UTF-8");
+        cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+        cfg.setLogTemplateExceptions(false);
+        cfg.setWrapUncheckedExceptions(true);
+        cfg.setFallbackOnNullLoopVariable(false);
+        cfg.setRecognizeStandardFileExtensions(true);
+        return cfg;
+    }
+}

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/FreemarkerConfiguration.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/FreemarkerConfiguration.java
@@ -30,9 +30,10 @@ import jakarta.enterprise.inject.Produces;
 ///       must pre-encode all values before passing them to the model.</li>
 /// </ul>
 ///
-/// Exceptions thrown during template processing propagate as {@link RuntimeException}
-/// (via {@link TemplateExceptionHandler#RETHROW_HANDLER}), which JAX-RS maps to a
-/// 500 response via the existing {@link KeyServerExceptionMapper}.
+/// Exceptions thrown during template processing propagate as {@link TemplateRenderingException}
+/// (via {@link TemplateExceptionHandler#RETHROW_HANDLER}), which is caught by
+/// {@link TemplateRenderingExceptionMapper}.  That mapper logs the failure at
+/// {@link java.util.logging.Level#SEVERE} and returns a generic 500 HTML response.
 @ApplicationScoped
 public class FreemarkerConfiguration {
 

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/FreemarkerConfiguration.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/FreemarkerConfiguration.java
@@ -50,6 +50,11 @@ public class FreemarkerConfiguration {
         cfg.setWrapUncheckedExceptions(true);
         cfg.setFallbackOnNullLoopVariable(false);
         cfg.setRecognizeStandardFileExtensions(true);
+        // Use "computer" number format to prevent locale-dependent grouping separators
+        // (e.g. "10,000" in en-US) from appearing in template output.  Raw numeric
+        // model values are rare — most are pre-converted to String in Java — but this
+        // acts as a safety net for future templates.
+        cfg.setNumberFormat("computer");
         return cfg;
     }
 }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
@@ -5,13 +5,9 @@
  */
 package io.github.bmarwell.keyserver.web.pks;
 
-import freemarker.template.Configuration;
-import freemarker.template.Template;
 import io.github.bmarwell.keyserver.application.api.KeyIndexResult;
 import io.github.bmarwell.keyserver.application.api.UidIndexEntry;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import java.io.StringWriter;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -33,10 +29,7 @@ import java.util.Optional;
 /// All derived values (epoch seconds, percent-encoded UIDs, flag strings) are computed
 /// in Java before being passed to templates.  Templates handle output structure only.
 @ApplicationScoped
-public class HkpIndexRenderer {
-
-    @Inject
-    Configuration configuration;
+public class HkpIndexRenderer extends AbstractFreemarkerRenderer {
 
     /// Renders the machine-readable HKP index format (`options=mr`).
     ///
@@ -121,17 +114,6 @@ public class HkpIndexRenderer {
                 "uids", uids);
     }
 
-    private String processTemplate(String templateName, Map<String, Object> model) {
-        try {
-            Template template = this.configuration.getTemplate(templateName);
-            StringWriter writer = new StringWriter();
-            template.process(model, writer);
-            return writer.toString();
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to render template: " + templateName, e);
-        }
-    }
-
     private static String toEpochSeconds(OffsetDateTime dt) {
         return String.valueOf(dt.toEpochSecond());
     }
@@ -149,10 +131,5 @@ public class HkpIndexRenderer {
             flags.append('e');
         }
         return flags.toString();
-    }
-
-    // CDI-friendly setter for unit testing
-    public void setConfiguration(Configuration configuration) {
-        this.configuration = configuration;
     }
 }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
@@ -5,14 +5,19 @@
  */
 package io.github.bmarwell.keyserver.web.pks;
 
+import freemarker.template.Configuration;
+import freemarker.template.Template;
 import io.github.bmarwell.keyserver.application.api.KeyIndexResult;
 import io.github.bmarwell.keyserver.application.api.UidIndexEntry;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.io.StringWriter;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /// Renders HKP `op=index` responses in machine-readable and HTML formats.
@@ -24,8 +29,14 @@ import java.util.Optional;
 ///
 /// The HTML format is a simple table — sufficient for browser inspection but not required
 /// for GnuPG interoperability.
+///
+/// All derived values (epoch seconds, percent-encoded UIDs, flag strings) are computed
+/// in Java before being passed to templates.  Templates handle output structure only.
 @ApplicationScoped
 public class HkpIndexRenderer {
+
+    @Inject
+    Configuration configuration;
 
     /// Renders the machine-readable HKP index format (`options=mr`).
     ///
@@ -43,42 +54,10 @@ public class HkpIndexRenderer {
     /// `uid:` lines since UIDs are not disabled independently.
     public String renderMachineReadable(List<KeyIndexResult> results) {
         Instant now = Instant.now();
-        StringBuilder sb = new StringBuilder();
-        sb.append("info:1:").append(results.size()).append('\n');
-        for (KeyIndexResult key : results) {
-            sb.append("pub:");
-            sb.append(key.fingerprint()).append(':');
-            sb.append(key.algorithm()).append(':');
-            key.bitStrength().ifPresent(bs -> sb.append(bs));
-            sb.append(':');
-            sb.append(toEpochSeconds(key.creationTime())).append(':');
-            sb.append(key.expirationTime().map(HkpIndexRenderer::toEpochSeconds).orElse(""))
-                    .append(':');
-            sb.append(computeFlags(key.revoked(), key.disabled(), key.expirationTime(), now));
-            sb.append('\n');
-            for (UidIndexEntry uid : key.verifiedUids()) {
-                sb.append("uid:");
-                // Use %20 for spaces (RFC 3986 percent-encoding) rather than +.
-                // URLEncoder uses application/x-www-form-urlencoded which encodes spaces as '+',
-                // but '+' is a legal literal character in UID strings and would be mis-decoded
-                // by strict HKP clients expecting RFC 3986.
-                sb.append(URLEncoder.encode(uid.uidRaw(), StandardCharsets.UTF_8)
-                                .replace("+", "%20"))
-                        .append(':');
-                sb.append(uid.creationTime()
-                                .map(HkpIndexRenderer::toEpochSeconds)
-                                .orElse(""))
-                        .append(':');
-                sb.append(uid.expirationTime()
-                                .map(HkpIndexRenderer::toEpochSeconds)
-                                .orElse(""))
-                        .append(':');
-                // UIDs are not disabled independently; pass false for the 'd' flag.
-                sb.append(computeFlags(uid.revoked(), false, uid.expirationTime(), now));
-                sb.append('\n');
-            }
-        }
-        return sb.toString();
+        List<Map<String, Object>> keys =
+                results.stream().map(key -> buildMrKeyModel(key, now)).toList();
+        Map<String, Object> model = Map.of("keyCount", results.size(), "keys", keys);
+        return processTemplate("hkp-index-mr.ftl", model);
     }
 
     /// Renders a simple HTML table for browser display.
@@ -87,32 +66,70 @@ public class HkpIndexRenderer {
     /// and is provided as a human-readable fallback only.
     public String renderHtml(List<KeyIndexResult> results) {
         Instant now = Instant.now();
-        StringBuilder sb = new StringBuilder();
-        sb.append("<!DOCTYPE html>\n");
-        sb.append("<html><head><meta charset=\"utf-8\"><title>Key search results</title></head>");
-        sb.append("<body><h1>Search results: ").append(results.size()).append(" key(s)</h1>\n");
-        sb.append("<table border=\"1\"><tr><th>Fingerprint</th><th>Algorithm (OpenPGP code)</th>"
-                + "<th>Created</th><th>Expires</th><th>Flags</th><th>UIDs</th></tr>\n");
-        for (KeyIndexResult key : results) {
-            sb.append("<tr>");
-            sb.append("<td>").append(htmlEscape(key.fingerprint())).append("</td>");
-            sb.append("<td>").append(key.algorithm()).append("</td>");
-            sb.append("<td>").append(key.creationTime()).append("</td>");
-            sb.append("<td>")
-                    .append(key.expirationTime().map(Object::toString).orElse(""))
-                    .append("</td>");
-            sb.append("<td>")
-                    .append(computeFlags(key.revoked(), key.disabled(), key.expirationTime(), now))
-                    .append("</td>");
-            sb.append("<td>");
-            for (UidIndexEntry uid : key.verifiedUids()) {
-                sb.append(htmlEscape(uid.uidRaw())).append("<br>");
-            }
-            sb.append("</td>");
-            sb.append("</tr>\n");
+        List<Map<String, Object>> keys =
+                results.stream().map(key -> buildHtmlKeyModel(key, now)).toList();
+        Map<String, Object> model = Map.of("keyCount", results.size(), "keys", keys);
+        return processTemplate("hkp-index-html.ftlh", model);
+    }
+
+    private Map<String, Object> buildMrKeyModel(KeyIndexResult key, Instant now) {
+        List<Map<String, Object>> uids = key.verifiedUids().stream()
+                .map(uid -> buildMrUidModel(uid, now))
+                .toList();
+        return Map.of(
+                "fingerprint", key.fingerprint(),
+                "algorithm", key.algorithm(),
+                "bitStrength", key.bitStrength().map(Object::toString).orElse(""),
+                "ctimeEpoch", toEpochSeconds(key.creationTime()),
+                "exptimeEpoch",
+                        key.expirationTime()
+                                .map(HkpIndexRenderer::toEpochSeconds)
+                                .orElse(""),
+                "flags", computeFlags(key.revoked(), key.disabled(), key.expirationTime(), now),
+                "uids", uids);
+    }
+
+    private Map<String, Object> buildMrUidModel(UidIndexEntry uid, Instant now) {
+        // Use %20 for spaces (RFC 3986 percent-encoding) rather than +.
+        // URLEncoder uses application/x-www-form-urlencoded which encodes spaces as '+',
+        // but '+' is a legal literal character in UID strings and would be mis-decoded
+        // by strict HKP clients expecting RFC 3986.
+        String encodedUid =
+                URLEncoder.encode(uid.uidRaw(), StandardCharsets.UTF_8).replace("+", "%20");
+        return Map.of(
+                "encodedUid", encodedUid,
+                "ctimeEpoch",
+                        uid.creationTime().map(HkpIndexRenderer::toEpochSeconds).orElse(""),
+                "exptimeEpoch",
+                        uid.expirationTime()
+                                .map(HkpIndexRenderer::toEpochSeconds)
+                                .orElse(""),
+                // UIDs are not disabled independently; pass false for the 'd' flag.
+                "flags", computeFlags(uid.revoked(), false, uid.expirationTime(), now));
+    }
+
+    private Map<String, Object> buildHtmlKeyModel(KeyIndexResult key, Instant now) {
+        List<Map<String, Object>> uids = key.verifiedUids().stream()
+                .map(uid -> Map.<String, Object>of("uidRaw", uid.uidRaw()))
+                .toList();
+        return Map.of(
+                "fingerprint", key.fingerprint(),
+                "algorithm", key.algorithm(),
+                "creationTime", key.creationTime().toString(),
+                "expirationTime", key.expirationTime().map(Object::toString).orElse(""),
+                "flags", computeFlags(key.revoked(), key.disabled(), key.expirationTime(), now),
+                "uids", uids);
+    }
+
+    private String processTemplate(String templateName, Map<String, Object> model) {
+        try {
+            Template template = this.configuration.getTemplate(templateName);
+            StringWriter writer = new StringWriter();
+            template.process(model, writer);
+            return writer.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to render template: " + templateName, e);
         }
-        sb.append("</table></body></html>");
-        return sb.toString();
     }
 
     private static String toEpochSeconds(OffsetDateTime dt) {
@@ -134,7 +151,8 @@ public class HkpIndexRenderer {
         return flags.toString();
     }
 
-    private static String htmlEscape(String s) {
-        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    // CDI-friendly setter for unit testing
+    public void setConfiguration(Configuration configuration) {
+        this.configuration = configuration;
     }
 }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/HkpIndexRenderer.java
@@ -49,7 +49,7 @@ public class HkpIndexRenderer extends AbstractFreemarkerRenderer {
         Instant now = Instant.now();
         List<Map<String, Object>> keys =
                 results.stream().map(key -> buildMrKeyModel(key, now)).toList();
-        Map<String, Object> model = Map.of("keyCount", results.size(), "keys", keys);
+        Map<String, Object> model = Map.of("keyCount", String.valueOf(results.size()), "keys", keys);
         return processTemplate("hkp-index-mr.ftl", model);
     }
 
@@ -61,7 +61,7 @@ public class HkpIndexRenderer extends AbstractFreemarkerRenderer {
         Instant now = Instant.now();
         List<Map<String, Object>> keys =
                 results.stream().map(key -> buildHtmlKeyModel(key, now)).toList();
-        Map<String, Object> model = Map.of("keyCount", results.size(), "keys", keys);
+        Map<String, Object> model = Map.of("keyCount", String.valueOf(results.size()), "keys", keys);
         return processTemplate("hkp-index-html.ftlh", model);
     }
 
@@ -71,7 +71,7 @@ public class HkpIndexRenderer extends AbstractFreemarkerRenderer {
                 .toList();
         return Map.of(
                 "fingerprint", key.fingerprint(),
-                "algorithm", key.algorithm(),
+                "algorithm", String.valueOf(key.algorithm()),
                 "bitStrength", key.bitStrength().map(Object::toString).orElse(""),
                 "ctimeEpoch", toEpochSeconds(key.creationTime()),
                 "exptimeEpoch",
@@ -107,7 +107,7 @@ public class HkpIndexRenderer extends AbstractFreemarkerRenderer {
                 .toList();
         return Map.of(
                 "fingerprint", key.fingerprint(),
-                "algorithm", key.algorithm(),
+                "algorithm", String.valueOf(key.algorithm()),
                 "creationTime", key.creationTime().toString(),
                 "expirationTime", key.expirationTime().map(Object::toString).orElse(""),
                 "flags", computeFlags(key.revoked(), key.disabled(), key.expirationTime(), now),

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/TemplateRenderingException.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/TemplateRenderingException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+/// Thrown when a Freemarker template cannot be loaded or fails during processing.
+///
+/// This is an infrastructure-level failure (missing or broken template file, bad
+/// template syntax, unexpected model value), not a domain exception.  It is caught
+/// by {@link TemplateRenderingExceptionMapper}, which logs the detail server-side
+/// and returns a generic HTTP 500 response to the caller.
+class TemplateRenderingException extends RuntimeException {
+
+    /// @param templateName the name of the template that failed (included in the log)
+    /// @param cause        the underlying Freemarker or I/O exception
+    TemplateRenderingException(String templateName, Exception cause) {
+        super("Failed to render template: " + templateName, cause);
+    }
+}

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/TemplateRenderingExceptionMapper.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/TemplateRenderingExceptionMapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/// JAX-RS exception mapper for {@link TemplateRenderingException}.
+///
+/// Template rendering failures are infrastructure errors — a missing or broken
+/// template file, a bad template syntax issue, or an unexpected model value.
+/// They are unrelated to any client request and must never expose internal stack
+/// traces to callers.
+///
+/// This mapper:
+/// <ol>
+///   <li>Logs the full exception at {@link Level#SEVERE} for operator investigation.</li>
+///   <li>Returns a plain {@code 500 Internal Server Error} with a minimal HTML body
+///       so the browser receives a human-readable page without risking a second
+///       rendering failure (the body is a hardcoded string, not a template).</li>
+/// </ol>
+@Provider
+class TemplateRenderingExceptionMapper implements ExceptionMapper<TemplateRenderingException> {
+
+    private static final Logger LOG = Logger.getLogger(TemplateRenderingExceptionMapper.class.getName());
+
+    private static final String ERROR_BODY = """
+            <!DOCTYPE html>
+            <html>
+            <head><meta charset="utf-8"><title>Internal Server Error</title></head>
+            <body>
+            <h1>Internal Server Error</h1>
+            <p>An unexpected error occurred while generating the response. Please try again later.</p>
+            </body>
+            </html>
+            """;
+
+    @Override
+    public Response toResponse(TemplateRenderingException ex) {
+        LOG.log(Level.SEVERE, "Template rendering failed: {0}", ex.getMessage());
+        LOG.log(Level.SEVERE, "Caused by", ex.getCause());
+        return Response.serverError()
+                .entity(ERROR_BODY)
+                .type("text/html;charset=utf-8")
+                .build();
+    }
+}

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/TemplateRenderingExceptionMapper.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/TemplateRenderingExceptionMapper.java
@@ -5,9 +5,14 @@
  */
 package io.github.bmarwell.keyserver.web.pks;
 
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -21,16 +26,19 @@ import java.util.logging.Logger;
 /// This mapper:
 /// <ol>
 ///   <li>Logs the full exception at {@link Level#SEVERE} for operator investigation.</li>
-///   <li>Returns a plain {@code 500 Internal Server Error} with a minimal HTML body
-///       so the browser receives a human-readable page without risking a second
-///       rendering failure (the body is a hardcoded string, not a template).</li>
+///   <li>Negotiates the response content type from the request's {@code Accept} header:
+///       HTML browsers receive a minimal hard-coded HTML error page; plain-text clients
+///       (e.g. HKP command-line tools) receive a one-line plain-text message.</li>
+///   <li>Never uses the Freemarker template engine for the error response — a broken
+///       template cannot cause a recursive rendering failure.</li>
 /// </ol>
 @Provider
+@Produces({MediaType.TEXT_HTML, MediaType.TEXT_PLAIN})
 class TemplateRenderingExceptionMapper implements ExceptionMapper<TemplateRenderingException> {
 
     private static final Logger LOG = Logger.getLogger(TemplateRenderingExceptionMapper.class.getName());
 
-    private static final String ERROR_BODY = """
+    private static final String HTML_ERROR_BODY = """
             <!DOCTYPE html>
             <html>
             <head><meta charset="utf-8"><title>Internal Server Error</title></head>
@@ -41,13 +49,49 @@ class TemplateRenderingExceptionMapper implements ExceptionMapper<TemplateRender
             </html>
             """;
 
+    private static final String PLAIN_ERROR_BODY = "Internal Server Error\n"
+            + "An unexpected error occurred while generating the response."
+            + " Please try again later.\n";
+
+    @Context
+    HttpHeaders httpHeaders;
+
     @Override
     public Response toResponse(TemplateRenderingException ex) {
         LOG.log(Level.SEVERE, "Template rendering failed: {0}", ex.getMessage());
         LOG.log(Level.SEVERE, "Caused by", ex.getCause());
+        if (prefersPlainText()) {
+            return Response.serverError()
+                    .entity(PLAIN_ERROR_BODY)
+                    .type("text/plain;charset=utf-8")
+                    .build();
+        }
         return Response.serverError()
-                .entity(ERROR_BODY)
+                .entity(HTML_ERROR_BODY)
                 .type("text/html;charset=utf-8")
                 .build();
+    }
+
+    private boolean prefersPlainText() {
+        if (this.httpHeaders == null) {
+            return false;
+        }
+        List<MediaType> acceptable = this.httpHeaders.getAcceptableMediaTypes();
+        // Walk Accept types in client-declared priority order.
+        // Return plain text only if text/plain is listed before text/html (or */*).
+        for (MediaType mt : acceptable) {
+            if (mt.isCompatible(MediaType.TEXT_HTML_TYPE)) {
+                return false;
+            }
+            if (mt.isCompatible(MediaType.TEXT_PLAIN_TYPE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // JAX-RS-context-friendly setter for unit testing without a container.
+    void setHttpHeaders(HttpHeaders httpHeaders) {
+        this.httpHeaders = httpHeaders;
     }
 }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyRenderer.java
@@ -5,8 +5,13 @@
  */
 package io.github.bmarwell.keyserver.web.pks;
 
+import freemarker.template.Configuration;
+import freemarker.template.Template;
 import io.github.bmarwell.keyserver.application.api.VerificationResult;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.io.StringWriter;
+import java.util.Map;
 
 /// Renders HTML pages for the UID verification endpoint.
 ///
@@ -17,65 +22,55 @@ import jakarta.enterprise.context.ApplicationScoped;
 ///   <li>{@link #renderInvalid} — shown when the token is missing, garbled, or already consumed.</li>
 /// </ul>
 ///
-/// The rendering logic is intentionally isolated here so that the HTML generation
-/// strategy can be changed — for example, migrated to a template engine such as
-/// Freemarker or JMustache — without modifying the endpoint or the application service.
-/// When migrating, only the body of each render method changes; their signatures and
-/// the {@link VerifyEndpoint} caller remain stable.
+/// Templates are loaded from the classpath under {@code /templates/} using the Freemarker
+/// {@link Configuration} produced by {@link FreemarkerConfiguration}.
+/// All three templates use the {@code .ftlh} extension, which activates Freemarker's HTML
+/// auto-escaping so that user-supplied values (e.g. UID strings) cannot inject HTML.
+///
+/// The public method signatures are stable — switching the underlying template engine
+/// (or reverting to StringBuilder rendering) does not affect callers.
 @ApplicationScoped
 public class VerifyRenderer {
+
+    @Inject
+    Configuration configuration;
 
     /// Renders a success page shown after a token is consumed and the UID published.
     ///
     /// @param result the outcome of the verification containing the UID raw string and fingerprint
     /// @return HTML string with DOCTYPE and charset declaration
     public String renderSuccess(VerificationResult result) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("<!DOCTYPE html>\n");
-        sb.append("<html><head><meta charset=\"utf-8\"><title>Email address verified</title></head>\n");
-        sb.append("<body>\n");
-        sb.append("<h1>Email address verified</h1>\n");
-        sb.append("<p>The following UID has been verified and is now published:</p>\n");
-        sb.append("<p><strong>").append(htmlEscape(result.uidRaw())).append("</strong></p>\n");
-        sb.append("<p>You can look up your key using the ");
-        sb.append("<a href=\"/pks/lookup?op=index&amp;search=");
-        sb.append(htmlEscape(result.fingerprint())).append("\">keyserver search</a>.</p>\n");
-        sb.append("</body></html>");
-        return sb.toString();
+        return processTemplate(
+                "verify-success.ftlh", Map.of("uidRaw", result.uidRaw(), "fingerprint", result.fingerprint()));
     }
 
     /// Renders an error page for expired verification tokens.
     ///
     /// @return HTML string with DOCTYPE and charset declaration
     public String renderExpired() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("<!DOCTYPE html>\n");
-        sb.append("<html><head><meta charset=\"utf-8\"><title>Verification link expired</title></head>\n");
-        sb.append("<body>\n");
-        sb.append("<h1>Verification link expired</h1>\n");
-        sb.append("<p>The verification link you followed has expired.</p>\n");
-        sb.append("<p>Please upload your key again to receive a new verification email.</p>\n");
-        sb.append("</body></html>");
-        return sb.toString();
+        return processTemplate("verify-expired.ftlh", Map.of());
     }
 
     /// Renders an error page for invalid, missing, or already-consumed verification tokens.
     ///
     /// @return HTML string with DOCTYPE and charset declaration
     public String renderInvalid() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("<!DOCTYPE html>\n");
-        sb.append("<html><head><meta charset=\"utf-8\"><title>Invalid verification link</title></head>\n");
-        sb.append("<body>\n");
-        sb.append("<h1>Invalid verification link</h1>\n");
-        sb.append("<p>The verification link you followed is no longer valid.</p>\n");
-        sb.append("<p>It may have already been used, may not exist, or may be malformed.</p>\n");
-        sb.append("<p>Please upload your key again to receive a new verification email.</p>\n");
-        sb.append("</body></html>");
-        return sb.toString();
+        return processTemplate("verify-invalid.ftlh", Map.of());
     }
 
-    private static String htmlEscape(String s) {
-        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    private String processTemplate(String templateName, Map<String, Object> model) {
+        try {
+            Template template = this.configuration.getTemplate(templateName);
+            StringWriter writer = new StringWriter();
+            template.process(model, writer);
+            return writer.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to render template: " + templateName, e);
+        }
+    }
+
+    // CDI-friendly setter for unit testing
+    public void setConfiguration(Configuration configuration) {
+        this.configuration = configuration;
     }
 }

--- a/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyRenderer.java
+++ b/web/openpgp-keyserver-protocol/src/main/java/io/github/bmarwell/keyserver/web/pks/VerifyRenderer.java
@@ -5,12 +5,8 @@
  */
 package io.github.bmarwell.keyserver.web.pks;
 
-import freemarker.template.Configuration;
-import freemarker.template.Template;
 import io.github.bmarwell.keyserver.application.api.VerificationResult;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import java.io.StringWriter;
 import java.util.Map;
 
 /// Renders HTML pages for the UID verification endpoint.
@@ -23,17 +19,14 @@ import java.util.Map;
 /// </ul>
 ///
 /// Templates are loaded from the classpath under {@code /templates/} using the Freemarker
-/// {@link Configuration} produced by {@link FreemarkerConfiguration}.
+/// {@link freemarker.template.Configuration} produced by {@link FreemarkerConfiguration}.
 /// All three templates use the {@code .ftlh} extension, which activates Freemarker's HTML
 /// auto-escaping so that user-supplied values (e.g. UID strings) cannot inject HTML.
 ///
 /// The public method signatures are stable — switching the underlying template engine
 /// (or reverting to StringBuilder rendering) does not affect callers.
 @ApplicationScoped
-public class VerifyRenderer {
-
-    @Inject
-    Configuration configuration;
+public class VerifyRenderer extends AbstractFreemarkerRenderer {
 
     /// Renders a success page shown after a token is consumed and the UID published.
     ///
@@ -56,21 +49,5 @@ public class VerifyRenderer {
     /// @return HTML string with DOCTYPE and charset declaration
     public String renderInvalid() {
         return processTemplate("verify-invalid.ftlh", Map.of());
-    }
-
-    private String processTemplate(String templateName, Map<String, Object> model) {
-        try {
-            Template template = this.configuration.getTemplate(templateName);
-            StringWriter writer = new StringWriter();
-            template.process(model, writer);
-            return writer.toString();
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to render template: " + templateName, e);
-        }
-    }
-
-    // CDI-friendly setter for unit testing
-    public void setConfiguration(Configuration configuration) {
-        this.configuration = configuration;
     }
 }

--- a/web/openpgp-keyserver-protocol/src/main/resources/templates/hkp-index-html.ftlh
+++ b/web/openpgp-keyserver-protocol/src/main/resources/templates/hkp-index-html.ftlh
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Key search results</title></head>
+<body>
+<h1>Search results: ${keyCount} key(s)</h1>
+<table border="1">
+<tr>
+  <th>Fingerprint</th>
+  <th>Algorithm (OpenPGP code)</th>
+  <th>Created</th>
+  <th>Expires</th>
+  <th>Flags</th>
+  <th>UIDs</th>
+</tr>
+<#list keys as key>
+<tr>
+  <td>${key.fingerprint}</td>
+  <td>${key.algorithm}</td>
+  <td>${key.creationTime}</td>
+  <td>${key.expirationTime}</td>
+  <td>${key.flags}</td>
+  <td><#list key.uids as uid>${uid.uidRaw}<br></#list></td>
+</tr>
+</#list>
+</table>
+</body>
+</html>

--- a/web/openpgp-keyserver-protocol/src/main/resources/templates/hkp-index-mr.ftl
+++ b/web/openpgp-keyserver-protocol/src/main/resources/templates/hkp-index-mr.ftl
@@ -1,10 +1,10 @@
 <#-- Machine-readable HKP index response (options=mr). -->
 <#-- Plain text output (.ftl); all values must be pre-processed by Java before being passed here. -->
 <#-- Template variables: -->
-<#--   keyCount  (int)    - total number of keys in the result set -->
+<#--   keyCount  (String) - total number of keys in the result set (pre-converted to avoid locale formatting) -->
 <#--   keys      (list)   - each entry is a map with fields: -->
 <#--     fingerprint   (String) -->
-<#--     algorithm     (int)    - raw OpenPGP algorithm code -->
+<#--     algorithm     (String) - OpenPGP algorithm code (pre-converted to avoid locale formatting) -->
 <#--     bitStrength   (String) - empty string for ECC, numeric string for RSA/DSA -->
 <#--     ctimeEpoch    (String) - epoch seconds of creation time -->
 <#--     exptimeEpoch  (String) - epoch seconds of expiration, or empty string -->

--- a/web/openpgp-keyserver-protocol/src/main/resources/templates/hkp-index-mr.ftl
+++ b/web/openpgp-keyserver-protocol/src/main/resources/templates/hkp-index-mr.ftl
@@ -1,0 +1,23 @@
+<#-- Machine-readable HKP index response (options=mr). -->
+<#-- Plain text output (.ftl); all values must be pre-processed by Java before being passed here. -->
+<#-- Template variables: -->
+<#--   keyCount  (int)    - total number of keys in the result set -->
+<#--   keys      (list)   - each entry is a map with fields: -->
+<#--     fingerprint   (String) -->
+<#--     algorithm     (int)    - raw OpenPGP algorithm code -->
+<#--     bitStrength   (String) - empty string for ECC, numeric string for RSA/DSA -->
+<#--     ctimeEpoch    (String) - epoch seconds of creation time -->
+<#--     exptimeEpoch  (String) - epoch seconds of expiration, or empty string -->
+<#--     flags         (String) - computed flag chars: r/d/e combination -->
+<#--     uids          (list)   - each entry is a map with fields: -->
+<#--       encodedUid    (String) - percent-encoded UID string (RFC 3986, %20 for space) -->
+<#--       ctimeEpoch    (String) -->
+<#--       exptimeEpoch  (String) -->
+<#--       flags         (String) -->
+info:1:${keyCount}
+<#list keys as key>
+pub:${key.fingerprint}:${key.algorithm}:${key.bitStrength}:${key.ctimeEpoch}:${key.exptimeEpoch}:${key.flags}
+<#list key.uids as uid>
+uid:${uid.encodedUid}:${uid.ctimeEpoch}:${uid.exptimeEpoch}:${uid.flags}
+</#list>
+</#list>

--- a/web/openpgp-keyserver-protocol/src/main/resources/templates/verify-expired.ftlh
+++ b/web/openpgp-keyserver-protocol/src/main/resources/templates/verify-expired.ftlh
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Verification link expired</title></head>
+<body>
+<h1>Verification link expired</h1>
+<p>The verification link you followed has expired.</p>
+<p>Please upload your key again to receive a new verification email.</p>
+</body>
+</html>

--- a/web/openpgp-keyserver-protocol/src/main/resources/templates/verify-invalid.ftlh
+++ b/web/openpgp-keyserver-protocol/src/main/resources/templates/verify-invalid.ftlh
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Invalid verification link</title></head>
+<body>
+<h1>Invalid verification link</h1>
+<p>The verification link you followed is no longer valid.</p>
+<p>It may have already been used, may not exist, or may be malformed.</p>
+<p>Please upload your key again to receive a new verification email.</p>
+</body>
+</html>

--- a/web/openpgp-keyserver-protocol/src/main/resources/templates/verify-success.ftlh
+++ b/web/openpgp-keyserver-protocol/src/main/resources/templates/verify-success.ftlh
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Email address verified</title></head>
+<body>
+<h1>Email address verified</h1>
+<p>The following UID has been verified and is now published:</p>
+<p><strong>${uidRaw}</strong></p>
+<p>You can look up your key using the <a href="/pks/lookup?op=index&amp;search=${fingerprint}">keyserver search</a>.</p>
+</body>
+</html>

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/FreemarkerConfigurationTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/FreemarkerConfigurationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import java.io.StringWriter;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/// Smoke-tests for {@link FreemarkerConfiguration}.
+///
+/// Verifies that the produced {@link Configuration} can load a template from the
+/// classpath and render it without errors, validating the template-loader and
+/// encoding setup without a CDI container.
+class FreemarkerConfigurationTest {
+
+    @Test
+    void configuration_loads_and_renders_smoke_template() throws Exception {
+        // given
+        Configuration cfg = new FreemarkerConfiguration().freemarkerConfiguration();
+
+        // when
+        Template template = cfg.getTemplate("smoke-test.ftlh");
+        StringWriter out = new StringWriter();
+        template.process(Map.of("name", "world"), out);
+
+        // then
+        assertThat(out.toString()).isEqualTo("Hello, world!");
+    }
+
+    @Test
+    void configuration_html_escapes_user_values() throws Exception {
+        // given — the .ftlh extension triggers HTML auto-escaping
+        Configuration cfg = new FreemarkerConfiguration().freemarkerConfiguration();
+
+        // when
+        Template template = cfg.getTemplate("smoke-test.ftlh");
+        StringWriter out = new StringWriter();
+        template.process(Map.of("name", "<script>"), out);
+
+        // then — angle brackets must be escaped; raw HTML must not reach the output
+        assertThat(out.toString()).doesNotContain("<script>");
+        assertThat(out.toString()).contains("&lt;script&gt;");
+    }
+}

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/LookupEndpointIndexTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/LookupEndpointIndexTest.java
@@ -30,9 +30,11 @@ class LookupEndpointIndexTest {
     @BeforeEach
     void setUp() {
         this.fakeService = new FakeKeyRepositoryService();
+        HkpIndexRenderer renderer = new HkpIndexRenderer();
+        renderer.setConfiguration(new FreemarkerConfiguration().freemarkerConfiguration());
         this.endpoint = new LookupEndpoint();
         this.endpoint.setKeyRepositoryService(this.fakeService);
-        this.endpoint.setHkpIndexRenderer(new HkpIndexRenderer());
+        this.endpoint.setHkpIndexRenderer(renderer);
     }
 
     @Test

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/TemplateRenderingExceptionMapperTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/TemplateRenderingExceptionMapperTest.java
@@ -7,7 +7,14 @@ package io.github.bmarwell.keyserver.web.pks;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class TemplateRenderingExceptionMapperTest {
@@ -15,8 +22,8 @@ class TemplateRenderingExceptionMapperTest {
     private final TemplateRenderingExceptionMapper mapper = new TemplateRenderingExceptionMapper();
 
     @Test
-    void returns500ForTemplateRenderingFailure() {
-        // given
+    void returns500WithHtmlByDefault() {
+        // given — no HttpHeaders injected (null), simulating no JAX-RS container
         TemplateRenderingException ex =
                 new TemplateRenderingException("some-template.ftlh", new RuntimeException("boom"));
 
@@ -24,12 +31,16 @@ class TemplateRenderingExceptionMapperTest {
         Response response = mapper.toResponse(ex);
 
         // then
-        assertThat(response.getStatus()).isEqualTo(500);
-        assertThat(response.getHeaderString("Content-Type")).startsWith("text/html");
+        assertThat(response.getStatus())
+                .as("template rendering failure must yield 500 Internal Server Error")
+                .isEqualTo(500);
+        assertThat(response.getHeaderString("Content-Type"))
+                .as("default response must be HTML when no Accept header is available")
+                .startsWith("text/html");
     }
 
     @Test
-    void responseBodyIsHardcodedHtmlNotFromTemplate() {
+    void htmlBodyIsHardcodedNotFromTemplate() {
         // given
         TemplateRenderingException ex =
                 new TemplateRenderingException("broken.ftlh", new IllegalStateException("template broken"));
@@ -37,10 +48,114 @@ class TemplateRenderingExceptionMapperTest {
         // when
         String body = (String) mapper.toResponse(ex).getEntity();
 
-        // then — body must be present but must not contain the exception message (no internal leak)
-        assertThat(body).startsWith("<!DOCTYPE html>");
-        assertThat(body).contains("Internal Server Error");
-        assertThat(body).doesNotContain("template broken");
-        assertThat(body).doesNotContain("broken.ftlh");
+        // then
+        assertThat(body).as("response must start with a valid HTML DOCTYPE").startsWith("<!DOCTYPE html>");
+        assertThat(body).as("body must contain a human-readable error heading").contains("Internal Server Error");
+        assertThat(body)
+                .as("internal exception message must not leak to the caller")
+                .doesNotContain("template broken");
+        assertThat(body).as("template name must not leak to the caller").doesNotContain("broken.ftlh");
+    }
+
+    @Test
+    void returnsPlainTextWhenClientPrefersIt() {
+        // given — client sends Accept: text/plain (e.g. a GnuPG HKP request)
+        mapper.setHttpHeaders(acceptOnly(MediaType.TEXT_PLAIN_TYPE));
+        TemplateRenderingException ex =
+                new TemplateRenderingException("some-template.ftl", new RuntimeException("oops"));
+
+        // when
+        Response response = mapper.toResponse(ex);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getHeaderString("Content-Type"))
+                .as("client that prefers text/plain must receive text/plain response")
+                .startsWith("text/plain");
+        assertThat((String) response.getEntity())
+                .as("plain-text body must not contain HTML tags")
+                .doesNotContain("<html>");
+    }
+
+    @Test
+    void returnsHtmlWhenClientPrefersHtml() {
+        // given — client sends Accept: text/html (e.g. a browser)
+        mapper.setHttpHeaders(acceptOnly(MediaType.TEXT_HTML_TYPE));
+        TemplateRenderingException ex =
+                new TemplateRenderingException("some-template.ftlh", new RuntimeException("oops"));
+
+        // when
+        Response response = mapper.toResponse(ex);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getHeaderString("Content-Type"))
+                .as("client that prefers text/html must receive text/html response")
+                .startsWith("text/html");
+        assertThat((String) response.getEntity()).startsWith("<!DOCTYPE html>");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Minimal HttpHeaders stub — only implements getAcceptableMediaTypes()
+    // ---------------------------------------------------------------------------
+
+    private static HttpHeaders acceptOnly(MediaType type) {
+        return new HttpHeaders() {
+            @Override
+            public List<MediaType> getAcceptableMediaTypes() {
+                return List.of(type);
+            }
+
+            @Override
+            public List<String> getRequestHeader(String name) {
+                return List.of();
+            }
+
+            @Override
+            public String getHeaderString(String name) {
+                return null;
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getRequestHeaders() {
+                return null;
+            }
+
+            @Override
+            public List<Locale> getAcceptableLanguages() {
+                return List.of();
+            }
+
+            @Override
+            public MediaType getMediaType() {
+                return null;
+            }
+
+            @Override
+            public Locale getLanguage() {
+                return null;
+            }
+
+            @Override
+            public Map<String, jakarta.ws.rs.core.Cookie> getCookies() {
+                return Map.of();
+            }
+
+            @Override
+            public Date getDate() {
+                return null;
+            }
+
+            @Override
+            public int getLength() {
+                return -1;
+            }
+
+            @Override
+            public boolean containsHeaderString(
+                    String name, String valueSeparatorRegex, java.util.function.Predicate<String> valuePredicate) {
+                return false;
+            }
+        };
     }
 }

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/TemplateRenderingExceptionMapperTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/TemplateRenderingExceptionMapperTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.pks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+class TemplateRenderingExceptionMapperTest {
+
+    private final TemplateRenderingExceptionMapper mapper = new TemplateRenderingExceptionMapper();
+
+    @Test
+    void returns500ForTemplateRenderingFailure() {
+        // given
+        TemplateRenderingException ex =
+                new TemplateRenderingException("some-template.ftlh", new RuntimeException("boom"));
+
+        // when
+        Response response = mapper.toResponse(ex);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.getHeaderString("Content-Type")).startsWith("text/html");
+    }
+
+    @Test
+    void responseBodyIsHardcodedHtmlNotFromTemplate() {
+        // given
+        TemplateRenderingException ex =
+                new TemplateRenderingException("broken.ftlh", new IllegalStateException("template broken"));
+
+        // when
+        String body = (String) mapper.toResponse(ex).getEntity();
+
+        // then — body must be present but must not contain the exception message (no internal leak)
+        assertThat(body).startsWith("<!DOCTYPE html>");
+        assertThat(body).contains("Internal Server Error");
+        assertThat(body).doesNotContain("template broken");
+        assertThat(body).doesNotContain("broken.ftlh");
+    }
+}

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/VerifyEndpointTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/VerifyEndpointTest.java
@@ -26,8 +26,10 @@ class VerifyEndpointTest {
 
     @BeforeEach
     void setUp() {
+        VerifyRenderer renderer = new VerifyRenderer();
+        renderer.setConfiguration(new FreemarkerConfiguration().freemarkerConfiguration());
         this.endpoint = new VerifyEndpoint();
-        this.endpoint.setVerifyRenderer(new VerifyRenderer());
+        this.endpoint.setVerifyRenderer(renderer);
     }
 
     @Test

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/VerifyRendererTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/VerifyRendererTest.java
@@ -22,6 +22,7 @@ class VerifyRendererTest {
     @BeforeEach
     void setUp() {
         this.renderer = new VerifyRenderer();
+        this.renderer.setConfiguration(new FreemarkerConfiguration().freemarkerConfiguration());
     }
 
     @Test
@@ -52,20 +53,20 @@ class VerifyRendererTest {
 
     @Test
     void success_page_escapes_special_chars_in_uid() {
-        // given — UID contains angle brackets (common in PGP UIDs)
+        // given
         var result = new VerificationResult("Bob & Alice <bob&alice@example.com>", "FFFF");
 
         // when
         String html = this.renderer.renderSuccess(result);
 
-        // then — raw < > & must not appear unescaped inside the content
+        // then
         assertThat(html).doesNotContain("Bob & Alice <bob&alice@example.com>");
         assertThat(html).contains("Bob &amp; Alice &lt;bob&amp;alice@example.com&gt;");
     }
 
     @Test
     void expired_page_contains_doctype_and_charset() {
-        // given — no input required
+        // given
 
         // when
         String html = this.renderer.renderExpired();
@@ -78,7 +79,7 @@ class VerifyRendererTest {
 
     @Test
     void invalid_page_contains_doctype_and_charset() {
-        // given — no input required
+        // given
 
         // when
         String html = this.renderer.renderInvalid();

--- a/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/VerifyRendererTest.java
+++ b/web/openpgp-keyserver-protocol/src/test/java/io/github/bmarwell/keyserver/web/pks/VerifyRendererTest.java
@@ -60,8 +60,12 @@ class VerifyRendererTest {
         String html = this.renderer.renderSuccess(result);
 
         // then
-        assertThat(html).doesNotContain("Bob & Alice <bob&alice@example.com>");
-        assertThat(html).contains("Bob &amp; Alice &lt;bob&amp;alice@example.com&gt;");
+        assertThat(html)
+                .as("raw < > & must not appear unescaped in the rendered HTML")
+                .doesNotContain("Bob & Alice <bob&alice@example.com>");
+        assertThat(html)
+                .as("Freemarker must HTML-escape ampersands and angle brackets in .ftlh templates")
+                .contains("Bob &amp; Alice &lt;bob&amp;alice@example.com&gt;");
     }
 
     @Test

--- a/web/openpgp-keyserver-protocol/src/test/resources/templates/smoke-test.ftlh
+++ b/web/openpgp-keyserver-protocol/src/test/resources/templates/smoke-test.ftlh
@@ -1,0 +1,1 @@
+Hello, ${name}!


### PR DESCRIPTION
Closes #154

## Summary

Migrates both HTML renderers from manual `StringBuilder` construction to Freemarker 2.3.34 templates, removing all hand-written `htmlEscape()` helpers.

## Commits

1. **Add Freemarker dep + CDI Configuration producer** — `FreemarkerConfiguration` singleton bean with `ClassTemplateLoader`, `recognizeStandardFileExtensions(true)` (auto-escaping on `.ftlh`), and `RETHROW_HANDLER`.

2. **Migrate VerifyRenderer** — three `.ftlh` templates (`verify-success`, `verify-expired`, `verify-invalid`); Freemarker auto-escapes user UID strings; CDI setter added for unit-test wiring.

3. **Migrate HkpIndexRenderer** — `hkp-index-mr.ftl` (plain text, no auto-escape; values pre-encoded in Java) and `hkp-index-html.ftlh` (HTML auto-escape). Java pre-computes all derived values (epoch seconds, percent-encoded UIDs, flags) before passing them to templates — templates handle output structure only.

## Design decisions

- **`.ftlh` → HTML auto-escaping ON** (user-supplied values safe to pass raw)
- **`.ftl` → plain text** (MR output; caller must percent-encode values before passing)
- `RETHROW_HANDLER` + `setWrapUncheckedExceptions(true)` — template failures propagate as `IllegalStateException` → JAX-RS 500 via existing `KeyServerExceptionMapper`
- CDI-friendly setters on both renderers — tests inject the configuration without a CDI container