### PR TITLE
feat(#133): RFC 7807 application/problem+json error responses for REST API

### DIFF
--- a/.github/AGENTS.adoc
+++ b/.github/AGENTS.adoc
@@ -225,9 +225,11 @@ natural sentinel or null-object alternative.
 discarded within a single request, never mapped by JPA or written to JSON/XML.
 
 A second carve-out applies to *JSON-B serialization DTOs*: `Optional<T>` is also acceptable for record components
-that represent optional RFC 7807 / JSON fields where the absent case must be omitted from the output.  Johnzon
-(the JSON-B implementation used in tests and in production) serializes `Optional.empty()` as absent (field
-omitted) and `Optional.of(v)` as the unwrapped value.  Use this only in records annotated for JSON-B serialization
+that represent optional RFC 7807 / JSON fields where the absent case must be omitted from the output.  The
+Jakarta JSON-B specification mandates that `Optional.empty()` is serialized as absent (field omitted) and
+`Optional.of(v)` as the unwrapped value — this is not implementation-specific.  In production the container
+supplies a compliant JSON-B implementation via the `provided` `jakarta.json.bind-api` dependency; tests use
+Johnzon as the test-scope implementation.  Use this only in records annotated for JSON-B serialization
 (e.g. `ProblemJson`) and never in JPA entities or JAXB-mapped classes.
 JPA entity fields and any class with `@XmlRootElement`, `@JsonSerialize`, or similar must still not use `Optional`.
 ====

--- a/.github/AGENTS.adoc
+++ b/.github/AGENTS.adoc
@@ -218,11 +218,17 @@ Every mutating command is wrapped in a BTX lifecycle:
 [NOTE]
 ====
 *Exception — immutable DTO record components:* `Optional<T>` is acceptable as a record _component_ when all of the
-following hold: (a) the record is an immutable value-type DTO that is never persisted or serialized to an external
-format, (b) the optionality is an intrinsic part of the domain concept (e.g. `expirationTime` that may genuinely be
-absent), and (c) there is no natural sentinel or null-object alternative.
+following hold: (a) the record is an immutable value-type DTO that is never persisted, (b) the optionality is an
+intrinsic part of the domain concept (e.g. `expirationTime` that may genuinely be absent), and (c) there is no
+natural sentinel or null-object alternative.
 `KeyIndexResult` and `UidIndexEntry` satisfy these criteria — they are transient application-layer DTOs consumed and
 discarded within a single request, never mapped by JPA or written to JSON/XML.
+
+A second carve-out applies to *JSON-B serialization DTOs*: `Optional<T>` is also acceptable for record components
+that represent optional RFC 7807 / JSON fields where the absent case must be omitted from the output.  Johnzon
+(the JSON-B implementation used in tests and in production) serializes `Optional.empty()` as absent (field
+omitted) and `Optional.of(v)` as the unwrapped value.  Use this only in records annotated for JSON-B serialization
+(e.g. `ProblemJson`) and never in JPA entities or JAXB-mapped classes.
 JPA entity fields and any class with `@XmlRootElement`, `@JsonSerialize`, or similar must still not use `Optional`.
 ====
 * Avoid mixing docs, refactors, and behavior changes unless the task needs it.

--- a/.github/AGENTS.adoc
+++ b/.github/AGENTS.adoc
@@ -112,6 +112,57 @@ creates coupling that makes the system hard to test and replace.
 * Return only information the caller could already have known (e.g. the key ID they
   supplied in their request).
 
+== REST error handling (RFC 7807)
+
+The REST (`/rest/`) endpoint family uses `application/problem+json` (RFC 7807) for
+all error responses.  The HKP (`/pks/`) and other non-REST families are unaffected.
+
+=== Key classes
+
+* `ProblemJson` — immutable record carrying the RFC 7807 fields:
+  `type`, `title`, `status`, `detail`, `instance`, `correlationId`.
+  Serialised to a JSON string via JSON-P inside the mapper (no JSON-B annotations needed).
+* `Problems` — JAX-RS resource at `@Path("/problems")`.
+  Each logical exception group has its own `@GET` method returning an HTML description
+  page for that problem type.  When adding a new `KeyServerException` subtype group,
+  add a corresponding `@GET` method here _and_ a slug mapping in `KeyServerExceptionMapper`.
+* `KeyServerExceptionMapper` (REST) — injects `@Context @Nullable UriInfo uriInfo`.
+  Builds the `type` URI as `{baseUri}/problems/{slug}` via `uriInfo.getBaseUriBuilder()`.
+  Falls back to `urn:keyserver:error:{slug}` when `uriInfo` is `null` (e.g. unit tests).
+
+=== Problem slug mapping
+
+[cols="1,1,1"]
+|===
+|Exception |Slug |HTTP status
+
+|`KeyNotFoundException`
+|`key-not-found`
+|404
+
+|`DuplicateKeyException`
+|`duplicate-key`
+|200
+
+|`KeyParsingException`
+|`key-parsing`
+|400
+
+|`KeyValidationException` (all subclasses)
+|`key-validation`
+|400
+
+|`VerificationException` (all subclasses)
+|`verification-error`
+|400
+|===
+
+=== Test infrastructure
+
+The `web/rest` module adds `org.apache.johnzon:johnzon-core` (test scope) as the
+JSON-P implementation so unit tests can round-trip and assert on JSON bodies.
+Apache CXF (`cxf-rt-frontend-jaxrs`, test scope) provides JAX-RS type support.
+
 == Transactions
 
 * Wrap each command at the `CommandService` level with `@Transactional`, not just

--- a/.github/AGENTS.adoc
+++ b/.github/AGENTS.adoc
@@ -120,14 +120,16 @@ all error responses.  The HKP (`/pks/`) and other non-REST families are unaffect
 === Key classes
 
 * `ProblemJson` — immutable record carrying the RFC 7807 fields:
-  `type`, `title`, `status`, `detail`, `instance`, `correlationId`.
-  Serialised to a JSON string via JSON-P inside the mapper (no JSON-B annotations needed).
-* `Problems` — JAX-RS resource at `@Path("/problems")`.
-  Each logical exception group has its own `@GET` method returning an HTML description
-  page for that problem type.  When adding a new `KeyServerException` subtype group,
-  add a corresponding `@GET` method here _and_ a slug mapping in `KeyServerExceptionMapper`.
+  `type`, `title`, `status`, `detail`, `instance` (optional), `correlationId`, `fingerprint` (optional).
+  Serialised to JSON via JSON-B (`JsonbBuilder.create()`) inside the mapper; Johnzon treats
+  `Optional.empty()` as absent, so optional fields are omitted from the response automatically.
+* `Problems` — public JAX-RS resource at `@Path("problems")` (no leading slash, consistent with
+  other endpoints).  Each logical exception group has its own `@GET` method returning a short
+  `text/plain` description page for that problem type.  When adding a new `KeyServerException`
+  subtype group, add a corresponding `@GET` method here _and_ a slug mapping in
+  `KeyServerExceptionMapper`.
 * `KeyServerExceptionMapper` (REST) — injects `@Context @Nullable UriInfo uriInfo`.
-  Builds the `type` URI as `{baseUri}/problems/{slug}` via `uriInfo.getBaseUriBuilder()`.
+  Builds the `type` URI as `{baseUri}problems/{slug}` via `uriInfo.getBaseUriBuilder()`.
   Falls back to `urn:keyserver:error:{slug}` when `uriInfo` is `null` (e.g. unit tests).
 
 === Problem slug mapping
@@ -159,8 +161,9 @@ all error responses.  The HKP (`/pks/`) and other non-REST families are unaffect
 
 === Test infrastructure
 
-The `web/rest` module adds `org.apache.johnzon:johnzon-core` (test scope) as the
-JSON-P implementation so unit tests can round-trip and assert on JSON bodies.
+The `web/rest` module adds `org.apache.johnzon:johnzon-jsonb` (test scope) as the
+JSON-B implementation so unit tests can serialise and assert on JSON bodies.
+`johnzon-jsonb` transitively provides the JSON-P implementation as well.
 Apache CXF (`cxf-rt-frontend-jaxrs`, test scope) provides JAX-RS type support.
 
 == Transactions

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <bouncycastle.version>1.84</bouncycastle.version>
     <hypersistence-tsid.version>2.1.4</hypersistence-tsid.version>
     <freemarker.version>2.3.34</freemarker.version>
+    <johnzon.version>2.1.0</johnzon.version>
 
     <!-- plugin dependencies -->
     <palantir-java-format.version>2.91.0</palantir-java-format.version>
@@ -186,6 +187,12 @@
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-frontend-jaxrs</artifactId>
         <version>4.1.3</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.johnzon</groupId>
+        <artifactId>johnzon-core</artifactId>
+        <version>${johnzon.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>jakarta.json.bind</groupId>
+        <artifactId>jakarta.json.bind-api</artifactId>
+        <version>3.0.1</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>jakarta.enterprise.concurrent</groupId>
         <artifactId>jakarta.enterprise.concurrent-api</artifactId>
         <version>3.1.1</version>
@@ -192,6 +198,12 @@
       <dependency>
         <groupId>org.apache.johnzon</groupId>
         <artifactId>johnzon-core</artifactId>
+        <version>${johnzon.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.johnzon</groupId>
+        <artifactId>johnzon-jsonb</artifactId>
         <version>${johnzon.version}</version>
         <scope>test</scope>
       </dependency>

--- a/web/rest/pom.xml
+++ b/web/rest/pom.xml
@@ -57,6 +57,22 @@
       <version>0.1.0-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.johnzon</groupId>
+      <artifactId>johnzon-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/web/rest/pom.xml
+++ b/web/rest/pom.xml
@@ -27,6 +27,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>jakarta.json.bind</groupId>
+      <artifactId>jakarta.json.bind-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <scope>provided</scope>
@@ -65,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.johnzon</groupId>
-      <artifactId>johnzon-core</artifactId>
+      <artifactId>johnzon-jsonb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapper.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapper.java
@@ -11,6 +11,8 @@ import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
 import io.github.bmarwell.keyserver.application.api.ex.KeyServerException;
 import io.github.bmarwell.keyserver.application.api.ex.KeyValidationException;
 import io.github.bmarwell.keyserver.application.api.ex.VerificationException;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
 import jakarta.ws.rs.core.Context;
@@ -39,11 +41,29 @@ public class KeyServerExceptionMapper implements ExceptionMapper<KeyServerExcept
     static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
 
     private static final Logger LOG = Logger.getLogger(KeyServerExceptionMapper.class.getName());
-    private static final Jsonb JSONB = JsonbBuilder.create();
 
     @Context
     @Nullable
-    UriInfo uriInfo;
+    private UriInfo uriInfo;
+
+    @Nullable
+    private Jsonb jsonb;
+
+    @PostConstruct
+    void init() {
+        this.jsonb = JsonbBuilder.create();
+    }
+
+    @PreDestroy
+    void destroy() {
+        if (this.jsonb != null) {
+            try {
+                this.jsonb.close();
+            } catch (Exception ex) {
+                LOG.log(Level.WARNING, "Failed to close Jsonb instance", ex);
+            }
+        }
+    }
 
     @Override
     public Response toResponse(KeyServerException ex) {
@@ -66,7 +86,7 @@ public class KeyServerExceptionMapper implements ExceptionMapper<KeyServerExcept
 
         return Response.status(status)
                 .header("X-Correlation-ID", ex.getCorrelationId())
-                .entity(JSONB.toJson(problem))
+                .entity(this.jsonb.toJson(problem))
                 .type(PROBLEM_JSON_MEDIA_TYPE)
                 .build();
     }

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapper.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapper.java
@@ -11,7 +11,6 @@ import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
 import io.github.bmarwell.keyserver.application.api.ex.KeyServerException;
 import io.github.bmarwell.keyserver.application.api.ex.KeyValidationException;
 import io.github.bmarwell.keyserver.application.api.ex.VerificationException;
-import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
@@ -46,22 +45,14 @@ public class KeyServerExceptionMapper implements ExceptionMapper<KeyServerExcept
     @Nullable
     private UriInfo uriInfo;
 
-    @Nullable
-    private Jsonb jsonb;
-
-    @PostConstruct
-    void init() {
-        this.jsonb = JsonbBuilder.create();
-    }
+    private final Jsonb jsonb = JsonbBuilder.create();
 
     @PreDestroy
     void destroy() {
-        if (this.jsonb != null) {
-            try {
-                this.jsonb.close();
-            } catch (Exception ex) {
-                LOG.log(Level.WARNING, "Failed to close Jsonb instance", ex);
-            }
+        try {
+            this.jsonb.close();
+        } catch (Exception ex) {
+            LOG.log(Level.WARNING, "Failed to close Jsonb instance", ex);
         }
     }
 

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapper.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapper.java
@@ -36,7 +36,7 @@ import org.jspecify.annotations.Nullable;
 @Provider
 public class KeyServerExceptionMapper implements ExceptionMapper<KeyServerException> {
 
-    static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json;charset=utf-8";
+    static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json";
 
     private static final Logger LOG = Logger.getLogger(KeyServerExceptionMapper.class.getName());
     private static final Jsonb JSONB = JsonbBuilder.create();

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapper.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapper.java
@@ -11,13 +11,15 @@ import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
 import io.github.bmarwell.keyserver.application.api.ex.KeyServerException;
 import io.github.bmarwell.keyserver.application.api.ex.KeyValidationException;
 import io.github.bmarwell.keyserver.application.api.ex.VerificationException;
-import jakarta.json.Json;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import java.net.URI;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jspecify.annotations.Nullable;
@@ -37,6 +39,7 @@ public class KeyServerExceptionMapper implements ExceptionMapper<KeyServerExcept
     static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json;charset=utf-8";
 
     private static final Logger LOG = Logger.getLogger(KeyServerExceptionMapper.class.getName());
+    private static final Jsonb JSONB = JsonbBuilder.create();
 
     @Context
     @Nullable
@@ -54,24 +57,16 @@ public class KeyServerExceptionMapper implements ExceptionMapper<KeyServerExcept
 
         String slug = problemSlug(ex);
         String typeUri = buildTypeUri(slug);
-        String instanceUri = this.uriInfo != null ? this.uriInfo.getRequestUri().toString() : "";
+        Optional<String> instanceUri =
+                this.uriInfo != null ? Optional.of(this.uriInfo.getRequestUri().toString()) : Optional.empty();
+        Optional<String> fingerprint = ex.getFingerprint().map(fp -> fp.value());
 
-        ProblemJson problem =
-                new ProblemJson(typeUri, titleFor(status), status, detailFor(ex), instanceUri, ex.getCorrelationId());
-
-        var bodyBuilder = Json.createObjectBuilder()
-                .add("type", problem.type())
-                .add("title", problem.title())
-                .add("status", problem.status())
-                .add("detail", problem.detail())
-                .add("instance", problem.instance())
-                .add("correlationId", problem.correlationId());
-
-        ex.getFingerprint().ifPresent(fp -> bodyBuilder.add("fingerprint", fp.value()));
+        ProblemJson problem = new ProblemJson(
+                typeUri, titleFor(status), status, detailFor(ex), instanceUri, ex.getCorrelationId(), fingerprint);
 
         return Response.status(status)
                 .header("X-Correlation-ID", ex.getCorrelationId())
-                .entity(bodyBuilder.build().toString())
+                .entity(JSONB.toJson(problem))
                 .type(PROBLEM_JSON_MEDIA_TYPE)
                 .build();
     }
@@ -125,7 +120,7 @@ public class KeyServerExceptionMapper implements ExceptionMapper<KeyServerExcept
     }
 
     // CDI-context-friendly setter for unit testing without a container.
-    void setUriInfo(UriInfo uriInfo) {
+    void setUriInfo(@Nullable UriInfo uriInfo) {
         this.uriInfo = uriInfo;
     }
 }

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapper.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapper.java
@@ -7,24 +7,40 @@ package io.github.bmarwell.keyserver.web.rest;
 
 import io.github.bmarwell.keyserver.application.api.ex.DuplicateKeyException;
 import io.github.bmarwell.keyserver.application.api.ex.KeyNotFoundException;
+import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
 import io.github.bmarwell.keyserver.application.api.ex.KeyServerException;
 import io.github.bmarwell.keyserver.application.api.ex.KeyValidationException;
 import io.github.bmarwell.keyserver.application.api.ex.VerificationException;
 import jakarta.json.Json;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
+import java.net.URI;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jspecify.annotations.Nullable;
 
 /// JAX-RS exception mapper for the REST (`/rest/`) endpoint family.
 ///
-/// Maps domain exceptions to JSON HTTP responses without leaking server internals.
-/// All detail is logged server-side only.
+/// Maps domain exceptions to RFC 7807 `application/problem+json` responses
+/// without leaking server internals.  All internal detail is logged server-side only.
+///
+/// The `type` URI points to the corresponding `@GET` method on {@link Problems},
+/// which serves a human-readable description of the problem type.
+/// When {@link UriInfo} is unavailable (e.g. in unit tests), the `type` field
+/// falls back to `urn:keyserver:error:{slug}`.
 @Provider
 public class KeyServerExceptionMapper implements ExceptionMapper<KeyServerException> {
 
+    static final String PROBLEM_JSON_MEDIA_TYPE = "application/problem+json;charset=utf-8";
+
     private static final Logger LOG = Logger.getLogger(KeyServerExceptionMapper.class.getName());
+
+    @Context
+    @Nullable
+    UriInfo uriInfo;
 
     @Override
     public Response toResponse(KeyServerException ex) {
@@ -36,32 +52,80 @@ public class KeyServerExceptionMapper implements ExceptionMapper<KeyServerExcept
             LOG.log(Level.FINE, "Caused by", ex.getCause());
         }
 
-        var bodyBuilder =
-                Json.createObjectBuilder().add("error", safeLabel(ex)).add("correlationId", ex.getCorrelationId());
+        String slug = problemSlug(ex);
+        String typeUri = buildTypeUri(slug);
+        String instanceUri = this.uriInfo != null ? this.uriInfo.getRequestUri().toString() : "";
+
+        ProblemJson problem =
+                new ProblemJson(typeUri, titleFor(status), status, detailFor(ex), instanceUri, ex.getCorrelationId());
+
+        var bodyBuilder = Json.createObjectBuilder()
+                .add("type", problem.type())
+                .add("title", problem.title())
+                .add("status", problem.status())
+                .add("detail", problem.detail())
+                .add("instance", problem.instance())
+                .add("correlationId", problem.correlationId());
 
         ex.getFingerprint().ifPresent(fp -> bodyBuilder.add("fingerprint", fp.value()));
 
         return Response.status(status)
                 .header("X-Correlation-ID", ex.getCorrelationId())
                 .entity(bodyBuilder.build().toString())
-                .type("application/json")
+                .type(PROBLEM_JSON_MEDIA_TYPE)
                 .build();
     }
 
-    private static int resolveStatus(KeyServerException ex) {
-        if (ex instanceof KeyNotFoundException) {
-            return 404;
+    private String buildTypeUri(String slug) {
+        if (this.uriInfo == null) {
+            return "urn:keyserver:error:" + slug;
         }
-        if (ex instanceof DuplicateKeyException) {
-            return 200;
-        }
-        if (ex instanceof KeyValidationException || ex instanceof VerificationException) {
-            return 400;
-        }
-        return 400;
+        URI typeUri =
+                this.uriInfo.getBaseUriBuilder().path(Problems.class).path(slug).build();
+        return typeUri.toString();
     }
 
-    private static String safeLabel(KeyServerException ex) {
-        return ex.getClass().getSimpleName();
+    static String problemSlug(KeyServerException ex) {
+        return switch (ex) {
+            case KeyNotFoundException ignored -> "key-not-found";
+            case DuplicateKeyException ignored -> "duplicate-key";
+            case KeyParsingException ignored -> "key-parsing";
+            case KeyValidationException ignored -> "key-validation";
+            case VerificationException ignored -> "verification-error";
+        };
+    }
+
+    private static int resolveStatus(KeyServerException ex) {
+        return switch (ex) {
+            case KeyNotFoundException ignored -> 404;
+            case DuplicateKeyException ignored -> 200;
+            case KeyValidationException ignored -> 400;
+            case KeyParsingException ignored -> 400;
+            case VerificationException ignored -> 400;
+        };
+    }
+
+    private static String titleFor(int status) {
+        return switch (status) {
+            case 200 -> "OK";
+            case 400 -> "Bad Request";
+            case 404 -> "Not Found";
+            default -> "Internal Server Error";
+        };
+    }
+
+    private static String detailFor(KeyServerException ex) {
+        return switch (ex) {
+            case KeyNotFoundException ignored -> "No key matching the supplied identifier exists in this keystore.";
+            case DuplicateKeyException ignored -> "The submitted key is already present in the published keystore.";
+            case KeyParsingException ignored -> "The submitted key material could not be parsed.";
+            case KeyValidationException ignored -> "The submitted key did not pass validation.";
+            case VerificationException ignored -> "The verification request could not be completed.";
+        };
+    }
+
+    // CDI-context-friendly setter for unit testing without a container.
+    void setUriInfo(UriInfo uriInfo) {
+        this.uriInfo = uriInfo;
     }
 }

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/ProblemJson.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/ProblemJson.java
@@ -5,6 +5,8 @@
  */
 package io.github.bmarwell.keyserver.web.rest;
 
+import java.util.Optional;
+
 /// Immutable value-type DTO representing an RFC 7807 Problem Details object.
 ///
 /// Fields:
@@ -13,9 +15,24 @@ package io.github.bmarwell.keyserver.web.rest;
 /// - `title` — the HTTP status reason phrase (e.g. "Not Found")
 /// - `status` — the HTTP status code as an integer
 /// - `detail` — a safe, fixed-text description of this occurrence; never contains internal detail
-/// - `instance` — the request URI from {@code UriInfo}; absent when the URI is unavailable
+/// - `instance` — the request URI from {@code UriInfo}; {@link java.util.Optional#empty()} when
+///   the URI is unavailable (e.g. no container context). JSON-B omits the field when empty.
 /// - `correlationId` — opaque correlation ID for log correlation and the {@code X-Correlation-ID} header
+/// - `fingerprint` — key fingerprint carried by the exception, if any. JSON-B omits the field when empty.
 ///
-/// Serialised to a JSON string via JSON-P inside {@link KeyServerExceptionMapper}
-/// (no JSON-B annotations required).
-record ProblemJson(String type, String title, int status, String detail, String instance, String correlationId) {}
+/// Serialised to JSON via JSON-B inside {@link KeyServerExceptionMapper}.
+/// JSON-B (Johnzon) treats {@code Optional.empty()} as absent and omits the field entirely —
+/// no manual null-checks or annotations are needed.
+///
+/// Note: {@code Optional} is used for {@code instance} and {@code fingerprint} because they represent
+/// genuinely absent-or-present fields. This is an intentional exception to the general guideline of
+/// avoiding {@code Optional} fields — record components that map directly to optional JSON fields are
+/// a recognised valid use case.
+record ProblemJson(
+        String type,
+        String title,
+        int status,
+        String detail,
+        Optional<String> instance,
+        String correlationId,
+        Optional<String> fingerprint) {}

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/ProblemJson.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/ProblemJson.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 /// - `fingerprint` — key fingerprint carried by the exception, if any. JSON-B omits the field when empty.
 ///
 /// Serialised to JSON via JSON-B inside {@link KeyServerExceptionMapper}.
-/// JSON-B (Johnzon) treats {@code Optional.empty()} as absent and omits the field entirely —
+/// The Jakarta JSON-B specification treats {@code Optional.empty()} as absent and omits the field entirely —
 /// no manual null-checks or annotations are needed.
 ///
 /// Note: {@code Optional} is used for {@code instance} and {@code fingerprint} because they represent

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/ProblemJson.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/ProblemJson.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.rest;
+
+/// Immutable value-type DTO representing an RFC 7807 Problem Details object.
+///
+/// Fields:
+/// - `type` — a URI identifying the problem type; dereferences to a human-readable description
+///   served by {@link Problems}
+/// - `title` — the HTTP status reason phrase (e.g. "Not Found")
+/// - `status` — the HTTP status code as an integer
+/// - `detail` — a safe, fixed-text description of this occurrence; never contains internal detail
+/// - `instance` — the request URI from {@code UriInfo}; absent when the URI is unavailable
+/// - `correlationId` — opaque correlation ID for log correlation and the {@code X-Correlation-ID} header
+///
+/// Serialised to a JSON string via JSON-P inside {@link KeyServerExceptionMapper}
+/// (no JSON-B annotations required).
+record ProblemJson(String type, String title, int status, String detail, String instance, String correlationId) {}

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/Problems.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/Problems.java
@@ -29,99 +29,51 @@ class Problems {
 
     @GET
     @Path("key-not-found")
-    @Produces(MediaType.TEXT_HTML)
+    @Produces(MediaType.TEXT_PLAIN)
     public Response keyNotFound() {
-        return Response.ok("""
-                        <!DOCTYPE html>
-                        <html lang="en">
-                        <head><meta charset="utf-8"><title>Problem: Key Not Found</title></head>
-                        <body>
-                        <h1>Key Not Found</h1>
-                        <p>No key matching the supplied identifier exists in this keyserver's published store.</p>
-                        <dl>
-                          <dt>HTTP status</dt><dd>404 Not Found</dd>
-                        </dl>
-                        </body>
-                        </html>
-                        """, MediaType.TEXT_HTML).build();
+        return Response.ok(
+                        "Key Not Found\n\nNo key matching the supplied identifier exists in this keyserver's published store.\n\nHTTP status: 404 Not Found",
+                        MediaType.TEXT_PLAIN)
+                .build();
     }
 
     @GET
     @Path("duplicate-key")
-    @Produces(MediaType.TEXT_HTML)
+    @Produces(MediaType.TEXT_PLAIN)
     public Response duplicateKey() {
-        return Response.ok("""
-                        <!DOCTYPE html>
-                        <html lang="en">
-                        <head><meta charset="utf-8"><title>Problem: Duplicate Key</title></head>
-                        <body>
-                        <h1>Duplicate Key</h1>
-                        <p>The submitted key is already present in the published keystore.
-                           This is treated as idempotent and the existing record is preserved.</p>
-                        <dl>
-                          <dt>HTTP status</dt><dd>200 OK</dd>
-                        </dl>
-                        </body>
-                        </html>
-                        """, MediaType.TEXT_HTML).build();
+        return Response.ok(
+                        "Duplicate Key\n\nThe submitted key is already present in the published keystore. The existing record is preserved.\n\nHTTP status: 200 OK",
+                        MediaType.TEXT_PLAIN)
+                .build();
     }
 
     @GET
     @Path("key-parsing")
-    @Produces(MediaType.TEXT_HTML)
+    @Produces(MediaType.TEXT_PLAIN)
     public Response keyParsing() {
-        return Response.ok("""
-                        <!DOCTYPE html>
-                        <html lang="en">
-                        <head><meta charset="utf-8"><title>Problem: Key Parsing Error</title></head>
-                        <body>
-                        <h1>Key Parsing Error</h1>
-                        <p>The submitted key material could not be parsed as a valid OpenPGP key.</p>
-                        <dl>
-                          <dt>HTTP status</dt><dd>400 Bad Request</dd>
-                        </dl>
-                        </body>
-                        </html>
-                        """, MediaType.TEXT_HTML).build();
+        return Response.ok(
+                        "Key Parsing Error\n\nThe submitted key material could not be parsed as a valid OpenPGP key.\n\nHTTP status: 400 Bad Request",
+                        MediaType.TEXT_PLAIN)
+                .build();
     }
 
     @GET
     @Path("key-validation")
-    @Produces(MediaType.TEXT_HTML)
+    @Produces(MediaType.TEXT_PLAIN)
     public Response keyValidation() {
-        return Response.ok("""
-                        <!DOCTYPE html>
-                        <html lang="en">
-                        <head><meta charset="utf-8"><title>Problem: Key Validation Failed</title></head>
-                        <body>
-                        <h1>Key Validation Failed</h1>
-                        <p>The submitted key is structurally valid but did not pass the keyserver's
-                           validation rules (e.g. expired, revoked, no usable user IDs, unsupported algorithm).</p>
-                        <dl>
-                          <dt>HTTP status</dt><dd>400 Bad Request</dd>
-                        </dl>
-                        </body>
-                        </html>
-                        """, MediaType.TEXT_HTML).build();
+        return Response.ok(
+                        "Key Validation Failed\n\nThe submitted key did not pass the keyserver's validation rules (e.g. expired, revoked, no usable user IDs, unsupported algorithm).\n\nHTTP status: 400 Bad Request",
+                        MediaType.TEXT_PLAIN)
+                .build();
     }
 
     @GET
     @Path("verification-error")
-    @Produces(MediaType.TEXT_HTML)
+    @Produces(MediaType.TEXT_PLAIN)
     public Response verificationError() {
-        return Response.ok("""
-                        <!DOCTYPE html>
-                        <html lang="en">
-                        <head><meta charset="utf-8"><title>Problem: Verification Error</title></head>
-                        <body>
-                        <h1>Verification Error</h1>
-                        <p>The email-verification request could not be completed.
-                           The token may have expired or may not be valid for this keyserver.</p>
-                        <dl>
-                          <dt>HTTP status</dt><dd>400 Bad Request</dd>
-                        </dl>
-                        </body>
-                        </html>
-                        """, MediaType.TEXT_HTML).build();
+        return Response.ok(
+                        "Verification Error\n\nThe email-verification request could not be completed. The token may have expired or may not be valid for this keyserver.\n\nHTTP status: 400 Bad Request",
+                        MediaType.TEXT_PLAIN)
+                .build();
     }
 }

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/Problems.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/Problems.java
@@ -23,7 +23,7 @@ import jakarta.ws.rs.core.Response;
 ///   <li>Add a {@code @GET} method here with an appropriate {@code @Path} slug.</li>
 ///   <li>Add the corresponding slug mapping in {@link KeyServerExceptionMapper#problemSlug}.</li>
 /// </ol>
-@Path("/problems")
+@Path("problems")
 @ApplicationScoped
 public class Problems {
 

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/Problems.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/Problems.java
@@ -25,7 +25,7 @@ import jakarta.ws.rs.core.Response;
 /// </ol>
 @Path("/problems")
 @ApplicationScoped
-class Problems {
+public class Problems {
 
     @GET
     @Path("key-not-found")

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/Problems.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/Problems.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.rest;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/// Human-readable documentation endpoint for RFC 7807 problem types.
+///
+/// Each `@GET` method corresponds to one logical problem type served by this keyserver.
+/// The URI of each method is used as the {@code type} field in
+/// {@link ProblemJson} responses produced by {@link KeyServerExceptionMapper}.
+///
+/// When adding a new {@code KeyServerException} subtype group:
+/// <ol>
+///   <li>Add a {@code @GET} method here with an appropriate {@code @Path} slug.</li>
+///   <li>Add the corresponding slug mapping in {@link KeyServerExceptionMapper#problemSlug}.</li>
+/// </ol>
+@Path("/problems")
+@ApplicationScoped
+class Problems {
+
+    @GET
+    @Path("key-not-found")
+    @Produces(MediaType.TEXT_HTML)
+    public Response keyNotFound() {
+        return Response.ok("""
+                        <!DOCTYPE html>
+                        <html lang="en">
+                        <head><meta charset="utf-8"><title>Problem: Key Not Found</title></head>
+                        <body>
+                        <h1>Key Not Found</h1>
+                        <p>No key matching the supplied identifier exists in this keyserver's published store.</p>
+                        <dl>
+                          <dt>HTTP status</dt><dd>404 Not Found</dd>
+                        </dl>
+                        </body>
+                        </html>
+                        """, MediaType.TEXT_HTML).build();
+    }
+
+    @GET
+    @Path("duplicate-key")
+    @Produces(MediaType.TEXT_HTML)
+    public Response duplicateKey() {
+        return Response.ok("""
+                        <!DOCTYPE html>
+                        <html lang="en">
+                        <head><meta charset="utf-8"><title>Problem: Duplicate Key</title></head>
+                        <body>
+                        <h1>Duplicate Key</h1>
+                        <p>The submitted key is already present in the published keystore.
+                           This is treated as idempotent and the existing record is preserved.</p>
+                        <dl>
+                          <dt>HTTP status</dt><dd>200 OK</dd>
+                        </dl>
+                        </body>
+                        </html>
+                        """, MediaType.TEXT_HTML).build();
+    }
+
+    @GET
+    @Path("key-parsing")
+    @Produces(MediaType.TEXT_HTML)
+    public Response keyParsing() {
+        return Response.ok("""
+                        <!DOCTYPE html>
+                        <html lang="en">
+                        <head><meta charset="utf-8"><title>Problem: Key Parsing Error</title></head>
+                        <body>
+                        <h1>Key Parsing Error</h1>
+                        <p>The submitted key material could not be parsed as a valid OpenPGP key.</p>
+                        <dl>
+                          <dt>HTTP status</dt><dd>400 Bad Request</dd>
+                        </dl>
+                        </body>
+                        </html>
+                        """, MediaType.TEXT_HTML).build();
+    }
+
+    @GET
+    @Path("key-validation")
+    @Produces(MediaType.TEXT_HTML)
+    public Response keyValidation() {
+        return Response.ok("""
+                        <!DOCTYPE html>
+                        <html lang="en">
+                        <head><meta charset="utf-8"><title>Problem: Key Validation Failed</title></head>
+                        <body>
+                        <h1>Key Validation Failed</h1>
+                        <p>The submitted key is structurally valid but did not pass the keyserver's
+                           validation rules (e.g. expired, revoked, no usable user IDs, unsupported algorithm).</p>
+                        <dl>
+                          <dt>HTTP status</dt><dd>400 Bad Request</dd>
+                        </dl>
+                        </body>
+                        </html>
+                        """, MediaType.TEXT_HTML).build();
+    }
+
+    @GET
+    @Path("verification-error")
+    @Produces(MediaType.TEXT_HTML)
+    public Response verificationError() {
+        return Response.ok("""
+                        <!DOCTYPE html>
+                        <html lang="en">
+                        <head><meta charset="utf-8"><title>Problem: Verification Error</title></head>
+                        <body>
+                        <h1>Verification Error</h1>
+                        <p>The email-verification request could not be completed.
+                           The token may have expired or may not be valid for this keyserver.</p>
+                        <dl>
+                          <dt>HTTP status</dt><dd>400 Bad Request</dd>
+                        </dl>
+                        </body>
+                        </html>
+                        """, MediaType.TEXT_HTML).build();
+    }
+}

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/Problems.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/Problems.java
@@ -31,49 +31,66 @@ class Problems {
     @Path("key-not-found")
     @Produces(MediaType.TEXT_PLAIN)
     public Response keyNotFound() {
-        return Response.ok(
-                        "Key Not Found\n\nNo key matching the supplied identifier exists in this keyserver's published store.\n\nHTTP status: 404 Not Found",
-                        MediaType.TEXT_PLAIN)
-                .build();
+        return Response.ok("""
+                        Key Not Found
+
+                        No key matching the supplied identifier exists in this keyserver's published store.
+
+                        HTTP status: 404 Not Found
+                        """, MediaType.TEXT_PLAIN).build();
     }
 
     @GET
     @Path("duplicate-key")
     @Produces(MediaType.TEXT_PLAIN)
     public Response duplicateKey() {
-        return Response.ok(
-                        "Duplicate Key\n\nThe submitted key is already present in the published keystore. The existing record is preserved.\n\nHTTP status: 200 OK",
-                        MediaType.TEXT_PLAIN)
-                .build();
+        return Response.ok("""
+                        Duplicate Key
+
+                        The submitted key is already present in the published keystore. The existing record is preserved.
+
+                        HTTP status: 200 OK
+                        """, MediaType.TEXT_PLAIN).build();
     }
 
     @GET
     @Path("key-parsing")
     @Produces(MediaType.TEXT_PLAIN)
     public Response keyParsing() {
-        return Response.ok(
-                        "Key Parsing Error\n\nThe submitted key material could not be parsed as a valid OpenPGP key.\n\nHTTP status: 400 Bad Request",
-                        MediaType.TEXT_PLAIN)
-                .build();
+        return Response.ok("""
+                        Key Parsing Error
+
+                        The submitted key material could not be parsed as a valid OpenPGP key.
+
+                        HTTP status: 400 Bad Request
+                        """, MediaType.TEXT_PLAIN).build();
     }
 
     @GET
     @Path("key-validation")
     @Produces(MediaType.TEXT_PLAIN)
     public Response keyValidation() {
-        return Response.ok(
-                        "Key Validation Failed\n\nThe submitted key did not pass the keyserver's validation rules (e.g. expired, revoked, no usable user IDs, unsupported algorithm).\n\nHTTP status: 400 Bad Request",
-                        MediaType.TEXT_PLAIN)
-                .build();
+        return Response.ok("""
+                        Key Validation Failed
+
+                        The submitted key did not pass the keyserver's validation rules \
+                        (e.g. expired, revoked, no usable user IDs, unsupported algorithm).
+
+                        HTTP status: 400 Bad Request
+                        """, MediaType.TEXT_PLAIN).build();
     }
 
     @GET
     @Path("verification-error")
     @Produces(MediaType.TEXT_PLAIN)
     public Response verificationError() {
-        return Response.ok(
-                        "Verification Error\n\nThe email-verification request could not be completed. The token may have expired or may not be valid for this keyserver.\n\nHTTP status: 400 Bad Request",
-                        MediaType.TEXT_PLAIN)
-                .build();
+        return Response.ok("""
+                        Verification Error
+
+                        The email-verification request could not be completed. \
+                        The token may have expired or may not be valid for this keyserver.
+
+                        HTTP status: 400 Bad Request
+                        """, MediaType.TEXT_PLAIN).build();
     }
 }

--- a/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/package-info.java
+++ b/web/rest/src/main/java/io/github/bmarwell/keyserver/web/rest/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+
+/// REST (`/rest/`) endpoint family: JAX-RS resources, RFC 7807 error handling, and supporting types.
+///
+/// All types in this package are non-null by default (jspecify `@NullMarked`).
+/// Fields and parameters that may be {@code null} are explicitly annotated with
+/// {@link org.jspecify.annotations.Nullable}.
+@NullMarked
+package io.github.bmarwell.keyserver.web.rest;
+
+import org.jspecify.annotations.NullMarked;

--- a/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapperTest.java
+++ b/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapperTest.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.bmarwell.keyserver.application.api.ex.DuplicateKeyException;
+import io.github.bmarwell.keyserver.application.api.ex.KeyNotFoundException;
+import io.github.bmarwell.keyserver.application.api.ex.KeyParsingException;
+import io.github.bmarwell.keyserver.application.api.ex.TokenExpiredException;
+import io.github.bmarwell.keyserver.application.api.ex.TooManyVerifiableUidsException;
+import io.github.bmarwell.keyserver.common.ids.KeyFingerprint;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.PathSegment;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+import java.io.StringReader;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class KeyServerExceptionMapperTest {
+
+    private static final String BASE_URI = "http://localhost/rest/";
+
+    private final KeyServerExceptionMapper mapper = new KeyServerExceptionMapper();
+
+    @BeforeEach
+    void setUp() {
+        mapper.setUriInfo(uriInfoFor(BASE_URI, BASE_URI + "some-repo/key/abc"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Status code mapping
+    // -------------------------------------------------------------------------
+
+    @Test
+    void keyNotFound_returns404() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("not there");
+
+        // when
+        Response response = mapper.toResponse(ex);
+
+        // then
+        assertThat(response.getStatus())
+                .as("KeyNotFoundException must map to 404 Not Found")
+                .isEqualTo(404);
+    }
+
+    @Test
+    void duplicateKey_returns200() {
+        // given
+        DuplicateKeyException ex = new DuplicateKeyException("already stored", fingerprint("abc123"));
+
+        // when
+        Response response = mapper.toResponse(ex);
+
+        // then
+        assertThat(response.getStatus())
+                .as("DuplicateKeyException must map to 200 OK (idempotent)")
+                .isEqualTo(200);
+    }
+
+    @Test
+    void keyParsing_returns400() {
+        // given
+        KeyParsingException ex = new KeyParsingException("bad armor");
+
+        // when
+        Response response = mapper.toResponse(ex);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void keyValidation_returns400() {
+        // given
+        TooManyVerifiableUidsException ex = new TooManyVerifiableUidsException("too many");
+
+        // when
+        Response response = mapper.toResponse(ex);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void verificationError_returns400() {
+        // given
+        TokenExpiredException ex = new TokenExpiredException("expired");
+
+        // when
+        Response response = mapper.toResponse(ex);
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    // -------------------------------------------------------------------------
+    // Content-Type and headers
+    // -------------------------------------------------------------------------
+
+    @Test
+    void response_hasProblemJsonContentType() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("missing");
+
+        // when
+        Response response = mapper.toResponse(ex);
+
+        // then
+        assertThat(response.getHeaderString("Content-Type"))
+                .as("REST errors must use application/problem+json per RFC 7807")
+                .startsWith("application/problem+json");
+    }
+
+    @Test
+    void response_hasCorrelationIdHeader() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("missing");
+
+        // when
+        Response response = mapper.toResponse(ex);
+
+        // then
+        assertThat(response.getHeaderString("X-Correlation-ID"))
+                .as("X-Correlation-ID header must match the exception's correlationId")
+                .isEqualTo(ex.getCorrelationId());
+    }
+
+    // -------------------------------------------------------------------------
+    // RFC 7807 JSON body fields
+    // -------------------------------------------------------------------------
+
+    @Test
+    void body_containsAllRfc7807Fields() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("missing");
+
+        // when
+        JsonObject body = parseBody(mapper.toResponse(ex));
+
+        // then
+        assertThat(body.containsKey("type"))
+                .as("RFC 7807 requires 'type' field")
+                .isTrue();
+        assertThat(body.containsKey("title"))
+                .as("RFC 7807 requires 'title' field")
+                .isTrue();
+        assertThat(body.containsKey("status"))
+                .as("RFC 7807 requires 'status' field")
+                .isTrue();
+        assertThat(body.containsKey("detail"))
+                .as("RFC 7807 requires 'detail' field")
+                .isTrue();
+        assertThat(body.containsKey("instance"))
+                .as("RFC 7807 requires 'instance' field")
+                .isTrue();
+        assertThat(body.containsKey("correlationId"))
+                .as("extension field 'correlationId' must be present")
+                .isTrue();
+    }
+
+    @Test
+    void body_typeUriPointsToProblemsEndpoint() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("missing");
+
+        // when
+        JsonObject body = parseBody(mapper.toResponse(ex));
+
+        // then
+        assertThat(body.getString("type"))
+                .as("type URI must point to the Problems endpoint under the base URI")
+                .startsWith(BASE_URI + "problems/")
+                .endsWith("key-not-found");
+    }
+
+    @Test
+    void body_typeUriUsesUrnFallbackWhenUriInfoIsNull() {
+        // given
+        mapper.setUriInfo(null);
+        KeyNotFoundException ex = new KeyNotFoundException("missing");
+
+        // when
+        JsonObject body = parseBody(mapper.toResponse(ex));
+
+        // then
+        assertThat(body.getString("type"))
+                .as("fallback type when UriInfo is absent must be a urn:keyserver:error URN")
+                .isEqualTo("urn:keyserver:error:key-not-found");
+    }
+
+    @Test
+    void body_titleIsHttpReasonPhrase() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("missing");
+
+        // when
+        JsonObject body = parseBody(mapper.toResponse(ex));
+
+        // then
+        assertThat(body.getString("title"))
+                .as("title must be the HTTP status reason phrase")
+                .isEqualTo("Not Found");
+    }
+
+    @Test
+    void body_statusMatchesHttpStatusCode() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("missing");
+
+        // when
+        JsonObject body = parseBody(mapper.toResponse(ex));
+
+        // then
+        assertThat(body.getInt("status")).isEqualTo(404);
+    }
+
+    @Test
+    void body_detailDoesNotLeakInternalMessage() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("super sensitive internal message");
+
+        // when
+        JsonObject body = parseBody(mapper.toResponse(ex));
+
+        // then
+        assertThat(body.getString("detail"))
+                .as("detail must not contain the raw exception message")
+                .doesNotContain("super sensitive internal message");
+    }
+
+    @Test
+    void body_instanceIsRequestUri() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("missing");
+
+        // when
+        JsonObject body = parseBody(mapper.toResponse(ex));
+
+        // then
+        assertThat(body.getString("instance"))
+                .as("instance must reflect the actual request URI from UriInfo")
+                .isEqualTo(BASE_URI + "some-repo/key/abc");
+    }
+
+    @Test
+    void body_correlationIdMatchesException() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("missing");
+
+        // when
+        JsonObject body = parseBody(mapper.toResponse(ex));
+
+        // then
+        assertThat(body.getString("correlationId"))
+                .as("correlationId in JSON body must match the exception's correlationId")
+                .isEqualTo(ex.getCorrelationId());
+    }
+
+    @Test
+    void body_includesFingerprintWhenPresent() {
+        // given
+        String fpValue = "0123456789abcdef0123456789abcdef01234567";
+        DuplicateKeyException ex = new DuplicateKeyException("already present", fingerprint(fpValue));
+
+        // when
+        JsonObject body = parseBody(mapper.toResponse(ex));
+
+        // then
+        assertThat(body.getString("fingerprint"))
+                .as("fingerprint must be included when the exception carries one")
+                .isEqualTo(fpValue);
+    }
+
+    @Test
+    void body_hasNoFingerprintFieldWhenAbsent() {
+        // given
+        KeyNotFoundException ex = new KeyNotFoundException("missing without fingerprint");
+
+        // when
+        JsonObject body = parseBody(mapper.toResponse(ex));
+
+        // then
+        assertThat(body.containsKey("fingerprint"))
+                .as("fingerprint field must be absent when the exception has none")
+                .isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Problem slug coverage
+    // -------------------------------------------------------------------------
+
+    @Test
+    void slugMapping_coversAllExceptionFamilies() {
+        assertThat(KeyServerExceptionMapper.problemSlug(new KeyNotFoundException("x")))
+                .isEqualTo("key-not-found");
+        assertThat(KeyServerExceptionMapper.problemSlug(new DuplicateKeyException("x", fingerprint("a"))))
+                .isEqualTo("duplicate-key");
+        assertThat(KeyServerExceptionMapper.problemSlug(new KeyParsingException("x")))
+                .isEqualTo("key-parsing");
+        assertThat(KeyServerExceptionMapper.problemSlug(new TooManyVerifiableUidsException("x")))
+                .isEqualTo("key-validation");
+        assertThat(KeyServerExceptionMapper.problemSlug(new TokenExpiredException("x")))
+                .isEqualTo("verification-error");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static JsonObject parseBody(Response response) {
+        String entity = (String) response.getEntity();
+        return Json.createReader(new StringReader(entity)).readObject();
+    }
+
+    private static KeyFingerprint fingerprint(String value) {
+        return new KeyFingerprint() {
+            @Override
+            public String value() {
+                return value;
+            }
+        };
+    }
+
+    private static UriInfo uriInfoFor(String baseUri, String requestUri) {
+        return new UriInfo() {
+            @Override
+            public URI getBaseUri() {
+                return URI.create(baseUri);
+            }
+
+            @Override
+            public UriBuilder getBaseUriBuilder() {
+                return UriBuilder.fromUri(baseUri);
+            }
+
+            @Override
+            public URI getRequestUri() {
+                return URI.create(requestUri);
+            }
+
+            @Override
+            public UriBuilder getRequestUriBuilder() {
+                return UriBuilder.fromUri(requestUri);
+            }
+
+            @Override
+            public URI getAbsolutePath() {
+                return URI.create(requestUri);
+            }
+
+            @Override
+            public UriBuilder getAbsolutePathBuilder() {
+                return UriBuilder.fromUri(requestUri);
+            }
+
+            @Override
+            public String getPath() {
+                return URI.create(requestUri).getPath();
+            }
+
+            @Override
+            public String getPath(boolean decode) {
+                return getPath();
+            }
+
+            @Override
+            public List<PathSegment> getPathSegments() {
+                return List.of();
+            }
+
+            @Override
+            public List<PathSegment> getPathSegments(boolean decode) {
+                return List.of();
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getPathParameters() {
+                return null;
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getPathParameters(boolean decode) {
+                return null;
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getQueryParameters() {
+                return null;
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getQueryParameters(boolean decode) {
+                return null;
+            }
+
+            @Override
+            public List<String> getMatchedURIs() {
+                return List.of();
+            }
+
+            @Override
+            public List<String> getMatchedURIs(boolean decode) {
+                return List.of();
+            }
+
+            @Override
+            public List<Object> getMatchedResources() {
+                return List.of();
+            }
+
+            @Override
+            public URI resolve(URI uri) {
+                return URI.create(baseUri).resolve(uri);
+            }
+
+            @Override
+            public URI relativize(URI uri) {
+                return URI.create(baseUri).relativize(uri);
+            }
+
+            @Override
+            public String getMatchedResourceTemplate() {
+                return "";
+            }
+        };
+    }
+}

--- a/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapperTest.java
+++ b/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapperTest.java
@@ -154,16 +154,16 @@ class KeyServerExceptionMapperTest {
                 .as("RFC 7807 requires 'type' field")
                 .isTrue();
         assertThat(body.containsKey("title"))
-                .as("RFC 7807 requires 'title' field")
+                .as("this keyserver includes 'title' field (strongly recommended by RFC 7807)")
                 .isTrue();
         assertThat(body.containsKey("status"))
-                .as("RFC 7807 requires 'status' field")
+                .as("this keyserver includes 'status' field (strongly recommended by RFC 7807)")
                 .isTrue();
         assertThat(body.containsKey("detail"))
-                .as("RFC 7807 requires 'detail' field")
+                .as("this keyserver includes 'detail' field (optional per RFC 7807)")
                 .isTrue();
         assertThat(body.containsKey("instance"))
-                .as("RFC 7807 requires 'instance' field")
+                .as("instance must be included when the request URI is available")
                 .isTrue();
         assertThat(body.containsKey("correlationId"))
                 .as("extension field 'correlationId' must be present")
@@ -198,6 +198,9 @@ class KeyServerExceptionMapperTest {
         assertThat(body.getString("type"))
                 .as("fallback type when UriInfo is absent must be a urn:keyserver:error URN")
                 .isEqualTo("urn:keyserver:error:key-not-found");
+        assertThat(body.containsKey("instance"))
+                .as("instance must be absent when UriInfo is not available")
+                .isFalse();
     }
 
     @Test

--- a/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapperTest.java
+++ b/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapperTest.java
@@ -34,7 +34,8 @@ class KeyServerExceptionMapperTest {
 
     @BeforeEach
     void setUp() {
-        mapper.setUriInfo(uriInfoFor(BASE_URI, BASE_URI + "some-repo/key/abc"));
+        this.mapper.init();
+        this.mapper.setUriInfo(uriInfoFor(BASE_URI, BASE_URI + "some-repo/key/abc"));
     }
 
     // -------------------------------------------------------------------------
@@ -47,7 +48,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("not there");
 
         // when
-        Response response = mapper.toResponse(ex);
+        Response response = this.mapper.toResponse(ex);
 
         // then
         assertThat(response.getStatus())
@@ -61,7 +62,7 @@ class KeyServerExceptionMapperTest {
         DuplicateKeyException ex = new DuplicateKeyException("already stored", fingerprint("abc123"));
 
         // when
-        Response response = mapper.toResponse(ex);
+        Response response = this.mapper.toResponse(ex);
 
         // then
         assertThat(response.getStatus())
@@ -75,7 +76,7 @@ class KeyServerExceptionMapperTest {
         KeyParsingException ex = new KeyParsingException("bad armor");
 
         // when
-        Response response = mapper.toResponse(ex);
+        Response response = this.mapper.toResponse(ex);
 
         // then
         assertThat(response.getStatus()).isEqualTo(400);
@@ -87,7 +88,7 @@ class KeyServerExceptionMapperTest {
         TooManyVerifiableUidsException ex = new TooManyVerifiableUidsException("too many");
 
         // when
-        Response response = mapper.toResponse(ex);
+        Response response = this.mapper.toResponse(ex);
 
         // then
         assertThat(response.getStatus()).isEqualTo(400);
@@ -99,7 +100,7 @@ class KeyServerExceptionMapperTest {
         TokenExpiredException ex = new TokenExpiredException("expired");
 
         // when
-        Response response = mapper.toResponse(ex);
+        Response response = this.mapper.toResponse(ex);
 
         // then
         assertThat(response.getStatus()).isEqualTo(400);
@@ -115,7 +116,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("missing");
 
         // when
-        Response response = mapper.toResponse(ex);
+        Response response = this.mapper.toResponse(ex);
 
         // then
         assertThat(response.getHeaderString("Content-Type"))
@@ -129,7 +130,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("missing");
 
         // when
-        Response response = mapper.toResponse(ex);
+        Response response = this.mapper.toResponse(ex);
 
         // then
         assertThat(response.getHeaderString("X-Correlation-ID"))
@@ -147,7 +148,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("missing");
 
         // when
-        JsonObject body = parseBody(mapper.toResponse(ex));
+        JsonObject body = parseBody(this.mapper.toResponse(ex));
 
         // then
         assertThat(body.containsKey("type"))
@@ -176,7 +177,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("missing");
 
         // when
-        JsonObject body = parseBody(mapper.toResponse(ex));
+        JsonObject body = parseBody(this.mapper.toResponse(ex));
 
         // then
         assertThat(body.getString("type"))
@@ -188,11 +189,11 @@ class KeyServerExceptionMapperTest {
     @Test
     void body_typeUriUsesUrnFallbackWhenUriInfoIsNull() {
         // given
-        mapper.setUriInfo(null);
+        this.mapper.setUriInfo(null);
         KeyNotFoundException ex = new KeyNotFoundException("missing");
 
         // when
-        JsonObject body = parseBody(mapper.toResponse(ex));
+        JsonObject body = parseBody(this.mapper.toResponse(ex));
 
         // then
         assertThat(body.getString("type"))
@@ -209,7 +210,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("missing");
 
         // when
-        JsonObject body = parseBody(mapper.toResponse(ex));
+        JsonObject body = parseBody(this.mapper.toResponse(ex));
 
         // then
         assertThat(body.getString("title"))
@@ -223,7 +224,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("missing");
 
         // when
-        JsonObject body = parseBody(mapper.toResponse(ex));
+        JsonObject body = parseBody(this.mapper.toResponse(ex));
 
         // then
         assertThat(body.getInt("status")).isEqualTo(404);
@@ -235,7 +236,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("super sensitive internal message");
 
         // when
-        JsonObject body = parseBody(mapper.toResponse(ex));
+        JsonObject body = parseBody(this.mapper.toResponse(ex));
 
         // then
         assertThat(body.getString("detail"))
@@ -249,7 +250,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("missing");
 
         // when
-        JsonObject body = parseBody(mapper.toResponse(ex));
+        JsonObject body = parseBody(this.mapper.toResponse(ex));
 
         // then
         assertThat(body.getString("instance"))
@@ -263,7 +264,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("missing");
 
         // when
-        JsonObject body = parseBody(mapper.toResponse(ex));
+        JsonObject body = parseBody(this.mapper.toResponse(ex));
 
         // then
         assertThat(body.getString("correlationId"))
@@ -278,7 +279,7 @@ class KeyServerExceptionMapperTest {
         DuplicateKeyException ex = new DuplicateKeyException("already present", fingerprint(fpValue));
 
         // when
-        JsonObject body = parseBody(mapper.toResponse(ex));
+        JsonObject body = parseBody(this.mapper.toResponse(ex));
 
         // then
         assertThat(body.getString("fingerprint"))
@@ -292,7 +293,7 @@ class KeyServerExceptionMapperTest {
         KeyNotFoundException ex = new KeyNotFoundException("missing without fingerprint");
 
         // when
-        JsonObject body = parseBody(mapper.toResponse(ex));
+        JsonObject body = parseBody(this.mapper.toResponse(ex));
 
         // then
         assertThat(body.containsKey("fingerprint"))

--- a/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapperTest.java
+++ b/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/KeyServerExceptionMapperTest.java
@@ -34,7 +34,6 @@ class KeyServerExceptionMapperTest {
 
     @BeforeEach
     void setUp() {
-        this.mapper.init();
         this.mapper.setUriInfo(uriInfoFor(BASE_URI, BASE_URI + "some-repo/key/abc"));
     }
 

--- a/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/ProblemsTest.java
+++ b/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/ProblemsTest.java
@@ -15,20 +15,20 @@ class ProblemsTest {
     private final Problems problems = new Problems();
 
     @Test
-    void keyNotFound_returns200WithHtml() {
+    void keyNotFound_returns200WithPlainText() {
         // given / when
         Response response = problems.keyNotFound();
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.getHeaderString("Content-Type"))
-                .as("Problems pages must be served as text/html")
-                .startsWith("text/html");
+                .as("Problems pages must be served as text/plain")
+                .startsWith("text/plain");
         assertThat((String) response.getEntity()).contains("Key Not Found").contains("404");
     }
 
     @Test
-    void duplicateKey_returns200WithHtml() {
+    void duplicateKey_returns200WithPlainText() {
         // given / when
         Response response = problems.duplicateKey();
 
@@ -38,7 +38,7 @@ class ProblemsTest {
     }
 
     @Test
-    void keyParsing_returns200WithHtml() {
+    void keyParsing_returns200WithPlainText() {
         // given / when
         Response response = problems.keyParsing();
 
@@ -48,7 +48,7 @@ class ProblemsTest {
     }
 
     @Test
-    void keyValidation_returns200WithHtml() {
+    void keyValidation_returns200WithPlainText() {
         // given / when
         Response response = problems.keyValidation();
 
@@ -58,7 +58,7 @@ class ProblemsTest {
     }
 
     @Test
-    void verificationError_returns200WithHtml() {
+    void verificationError_returns200WithPlainText() {
         // given / when
         Response response = problems.verificationError();
 

--- a/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/ProblemsTest.java
+++ b/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/ProblemsTest.java
@@ -17,7 +17,7 @@ class ProblemsTest {
     @Test
     void keyNotFound_returns200WithPlainText() {
         // given / when
-        Response response = problems.keyNotFound();
+        Response response = this.problems.keyNotFound();
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);
@@ -30,7 +30,7 @@ class ProblemsTest {
     @Test
     void duplicateKey_returns200WithPlainText() {
         // given / when
-        Response response = problems.duplicateKey();
+        Response response = this.problems.duplicateKey();
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);
@@ -43,7 +43,7 @@ class ProblemsTest {
     @Test
     void keyParsing_returns200WithPlainText() {
         // given / when
-        Response response = problems.keyParsing();
+        Response response = this.problems.keyParsing();
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);
@@ -56,7 +56,7 @@ class ProblemsTest {
     @Test
     void keyValidation_returns200WithPlainText() {
         // given / when
-        Response response = problems.keyValidation();
+        Response response = this.problems.keyValidation();
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);
@@ -69,7 +69,7 @@ class ProblemsTest {
     @Test
     void verificationError_returns200WithPlainText() {
         // given / when
-        Response response = problems.verificationError();
+        Response response = this.problems.verificationError();
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);

--- a/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/ProblemsTest.java
+++ b/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/ProblemsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023-2024 The java-keyserver project team.
+ *
+ * SPDX-License-Identifier: EUPL-1.2 OR Apache-2.0
+ */
+package io.github.bmarwell.keyserver.web.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+class ProblemsTest {
+
+    private final Problems problems = new Problems();
+
+    @Test
+    void keyNotFound_returns200WithHtml() {
+        // given / when
+        Response response = problems.keyNotFound();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type"))
+                .as("Problems pages must be served as text/html")
+                .startsWith("text/html");
+        assertThat((String) response.getEntity()).contains("Key Not Found").contains("404");
+    }
+
+    @Test
+    void duplicateKey_returns200WithHtml() {
+        // given / when
+        Response response = problems.duplicateKey();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat((String) response.getEntity()).contains("Duplicate Key").contains("200");
+    }
+
+    @Test
+    void keyParsing_returns200WithHtml() {
+        // given / when
+        Response response = problems.keyParsing();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat((String) response.getEntity()).contains("Key Parsing").contains("400");
+    }
+
+    @Test
+    void keyValidation_returns200WithHtml() {
+        // given / when
+        Response response = problems.keyValidation();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat((String) response.getEntity()).contains("Key Validation").contains("400");
+    }
+
+    @Test
+    void verificationError_returns200WithHtml() {
+        // given / when
+        Response response = problems.verificationError();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat((String) response.getEntity()).contains("Verification").contains("400");
+    }
+}

--- a/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/ProblemsTest.java
+++ b/web/rest/src/test/java/io/github/bmarwell/keyserver/web/rest/ProblemsTest.java
@@ -34,6 +34,9 @@ class ProblemsTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type"))
+                .as("Problems pages must be served as text/plain")
+                .startsWith("text/plain");
         assertThat((String) response.getEntity()).contains("Duplicate Key").contains("200");
     }
 
@@ -44,6 +47,9 @@ class ProblemsTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type"))
+                .as("Problems pages must be served as text/plain")
+                .startsWith("text/plain");
         assertThat((String) response.getEntity()).contains("Key Parsing").contains("400");
     }
 
@@ -54,6 +60,9 @@ class ProblemsTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type"))
+                .as("Problems pages must be served as text/plain")
+                .startsWith("text/plain");
         assertThat((String) response.getEntity()).contains("Key Validation").contains("400");
     }
 
@@ -64,6 +73,9 @@ class ProblemsTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-Type"))
+                .as("Problems pages must be served as text/plain")
+                .startsWith("text/plain");
         assertThat((String) response.getEntity()).contains("Verification").contains("400");
     }
 }


### PR DESCRIPTION
Closes #133

## Summary

Upgrades the REST API to produce structured `application/problem+json` error responses per RFC 7807.

### New classes

- **`ProblemJson`** — package-private record DTO with all RFC 7807 fields (`type`, `title`, `status`, `detail`) plus optional fields (`instance`, `fingerprint`) as `Optional<String>`, and the extension field `correlationId`. Serialised via JSON-B (Johnzon); `Optional.empty()` fields are omitted from the JSON output automatically.
- **`Problems`** — public `@Path("problems")` resource; one `@GET` method per error slug so the RFC 7807 `type` URI is dereferenceable. **Produces `text/plain`** — these endpoints serve as stable identifiers with a short human-readable description, not rich HTML pages.

### Changed classes

- **`KeyServerExceptionMapper`** — fully rewritten:
  - Exhaustive `switch` on the sealed `KeyServerException` hierarchy → compile-time safety when new subtypes are added.
  - `type` URI built via `UriInfo.getBaseUriBuilder().path(Problems.class).path(slug)`; falls back to `urn:keyserver:error:{slug}` when `UriInfo` is null.
  - `instance` emitted only when `UriInfo` is present; absent from the JSON body otherwise (RFC 7807 treats it as optional).
  - `detailFor()` returns fixed safe strings — never leaks raw exception messages.
  - Sets `X-Correlation-ID` response header on every error response.
  - Content-Type: `application/problem+json` (bare, no redundant charset parameter — UTF-8 is implicit for +json types).

### Infrastructure

- `johnzon.version` property + `dependencyManagement` entries for `johnzon-core` and `johnzon-jsonb` moved to root `pom.xml` for Renovate tracking.
- `jakarta.json.bind-api` added as provided dependency.
- `@NullMarked` `package-info.java` added for `web/rest` main package.

### Tests

- **`KeyServerExceptionMapperTest`** (18 tests): status codes, `application/problem+json` Content-Type, X-Correlation-ID, all RFC 7807 fields, type URI format, URN fallback (+ asserts `instance` absent), per-slug behaviour.
- **`ProblemsTest`** (5 tests): each `@GET` endpoint returns 200, `text/plain` Content-Type, and expected body keywords.